### PR TITLE
release(alego): 0.1.1

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego",
   "description": "alego CLI: profile boot, plugin management, and the browser UI alias",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-web-frontend",
   "description": "Web application entry: vite build over the @singula-ai/alego-client-web shell library; dist/ served by apps/cli's alego web",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singula-ai/alego-root",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/packages/acp/acp/package.json
+++ b/packages/acp/acp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-acp",
   "description": "Automation-only Agent Client Protocol server for driving Alego agents over JSON-RPC stdio",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/gateway/package.json
+++ b/packages/api/gateway/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-api-gateway",
   "description": "Typert Remote Host dispatcher and Client API endpoint",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/remotes/package.json
+++ b/packages/api/remotes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-api-remotes",
   "description": "Remote BFF assembly and Host Agent/Session lookup policy",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/attachment/attachment-local/package.json
+++ b/packages/attachment/attachment-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-attachment-local",
   "description": "Private content-addressed ALEGO_HOME attachment storage",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/attachment/attachment/package.json
+++ b/packages/attachment/attachment/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-attachment",
   "description": "Durable immutable attachment storage seam for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/boot/app-boot/package.json
+++ b/packages/boot/app-boot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-app-boot",
   "description": "Shared boot glue for the app bins: .env loading, fail-loud Loader guards, snapshot-aware config resolution, and the Loader boot sequence",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/boot/cmdline/package.json
+++ b/packages/boot/cmdline/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-cmdline",
   "description": "Immutable command-line handoff from an alego launcher to any app plugin that injects cmdlineArgs",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bundle/base/package.json
+++ b/packages/bundle/base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-base",
   "description": "The shared alego core as a profile bundle: every profile's first patch layer, inserting the base plugin rows over the empty profile root",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bundle/headless/package.json
+++ b/packages/bundle/headless/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-headless",
   "description": "The alego one-shot bundle: a direct core Agent/Session runner over alego-base with no Host, HTTP, or browser layer",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bundle/web-app/package.json
+++ b/packages/bundle/web-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-web-app",
   "description": "The alego browser-surface bundle: the web patch layer over alego-base plus the runtime glue plugin (frontend dist serving, web-surface prompt, bash runtime variables, URL line)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/connection/package.json
+++ b/packages/client/connection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-connection",
   "description": "Wire consumer layer: HTTP-up/WebSocket-down client, ConnectionController dual streams with reconnect, and fixture api",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/hmr/package.json
+++ b/packages/client/hmr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-hmr",
   "description": "Dev-only hot-reload driver for script-loaded client entries: SSE rebuilt frames → invalidate/prefetch → fiber swap through the vendored Loader entry",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/locale/package.json
+++ b/packages/client/locale/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-locale",
   "description": "Locale plugin: Host-backed zh/en preference, browser-derived fallback, locale snapshots, and typed namespace dictionaries",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/modules/package.json
+++ b/packages/client/modules/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-modules",
   "description": "Client module system, dual-face: node half composes the __ALEGO_BOOT__ entry graph (incremental alego.client scan, bundle route, index tap, webPlugins service); browser half is the lazy-CJS module table the vendored cordis Loader consumes as its internal seam",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/runtime/package.json
+++ b/packages/client/runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-runtime",
   "description": "Client core services: SlotRegistry, SessionRuntime (scope tree + object layer)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-agent-preset/package.json
+++ b/packages/client/ui-agent-preset/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-agent-preset",
   "description": "Agent-preset surfaces: the default for later sessions, this session's seat, and the composition editor",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-attachment/package.json
+++ b/packages/client/ui-attachment/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-attachment",
   "description": "Dynamic attachment presentation plugin for conversation input and message-image slots",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-brand-official/package.json
+++ b/packages/client/ui-brand-official/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-brand-official",
   "description": "Official Alego brand occupants for the Web client's sidebar and conversation Hero slots",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-commands/package.json
+++ b/packages/client/ui-commands/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-commands",
   "description": "Client command surface: global directory cache, '/' source, three command UI kinds, popupSelect registry",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-conversation/package.json
+++ b/packages/client/ui-conversation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-conversation",
   "description": "Conversation domain: skeleton, ordered chat flow, composer with the Host-backed busy-Enter preference, and details host",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-deliverables/package.json
+++ b/packages/client/ui-deliverables/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-deliverables",
   "description": "Produced-files turn tail and clickable final-response file references for Web",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-directory-picker-browse/package.json
+++ b/packages/client/ui-directory-picker-browse/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-directory-picker-browse",
   "description": "In-app directory browsing surface: the workspace directory-flow owner rendering the host's listing and creation primitives",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-directory-picker-native/package.json
+++ b/packages/client/ui-directory-picker-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-directory-picker-native",
   "description": "Native directory-picker surface: the renderless workspace directory-flow occupant driving the host's OS chooser",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-goal/package.json
+++ b/packages/client/ui-goal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-goal",
   "description": "Session goal surface: GoalBar docked above the composer, read from the goal session projection",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-input-trigger/package.json
+++ b/packages/client/ui-input-trigger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-input-trigger",
   "description": "Input trigger pipeline: '/' and '@' detection, candidate menu, pick routing to registered sources",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-jobs/package.json
+++ b/packages/client/ui-jobs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-jobs",
   "description": "Session-header background-job list: live registry state mirrored from session/jobs frames",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "type": "module",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/packages/client/ui-layout/package.json
+++ b/packages/client/ui-layout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-layout",
   "description": "Shell plugin: three-column AppFrame with drag handles, ctx.layout viewing-state service (navigation + panels)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-message-feedback/package.json
+++ b/packages/client/ui-message-feedback/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-message-feedback",
   "description": "Per-message feedback controls contributed to the assistant-message action strip, backed by the messageFeedback Host Remote",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-model-selection/package.json
+++ b/packages/client/ui-model-selection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-model-selection",
   "description": "Model selection: the /model popupSelect over session.models / session.selectModel",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-permission-presets/package.json
+++ b/packages/client/ui-permission-presets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-permission-presets",
   "description": "Permission surfaces: a new-session default in General settings and a current-session /permission popup over the permissions projection",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-plan/package.json
+++ b/packages/client/ui-plan/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-plan",
   "description": "Plan-mode composer control: the conversation.input.plan seat over the plan projection and the /plan command channel",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-primitives/package.json
+++ b/packages/client/ui-primitives/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-primitives",
   "description": "Pure React atoms for the alego web UI: controls, icons, markdown, and JSON inspectors (zero cordis)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-reference/package.json
+++ b/packages/client/ui-reference/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-reference",
   "description": "Unified Web @file and @session reference source",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-renderer/package.json
+++ b/packages/client/ui-renderer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-renderer",
   "description": "Browser UI renderer: React slot bindings, ctx.uiRenderer, and the assembled application root",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-settings-general/package.json
+++ b/packages/client/ui-settings-general/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-settings-general",
   "description": "Settings ownerless-copy and product onboarding plugin: the General section, shell trigger/header chrome content, settings dictionaries, and the versioned welcome notice",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-settings-models/package.json
+++ b/packages/client/ui-settings-models/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-settings-models",
   "description": "Models settings and shared product-onboarding dialogs over existing settings and credential joins",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-settings-plugin-inventory/package.json
+++ b/packages/client/ui-settings-plugin-inventory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-settings-plugin-inventory",
   "description": "Read-only Cordis Loader inventory tab in Web Plugins settings",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-settings-plugins/package.json
+++ b/packages/client/ui-settings-plugins/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-settings-plugins",
   "description": "Plugins settings section with feature-owned tabs and configurable host-plane plugin cards",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-settings/package.json
+++ b/packages/client/ui-settings/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-settings",
   "description": "Settings domain base plugin: the settings-namespace scope service and the canonical settings slot-type contract",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-sidebar/package.json
+++ b/packages/client/ui-sidebar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-sidebar",
   "description": "Sidebar plugin: session multi-level tree, search, grouping, state dots",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-skill/package.json
+++ b/packages/client/ui-skill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-skill",
   "description": "Web skill references and the dedicated skill tool row",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-slots/package.json
+++ b/packages/client/ui-slots/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-slots",
   "description": "Slot registry pure core: SlotMap declaration merging, single register composition API, four-share props types, store-seat types, renderer install seam",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-subagent/package.json
+++ b/packages/client/ui-subagent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-subagent",
   "description": "Subagent conversation catalog, continuation routing UI, and '@' reference source",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-theme/package.json
+++ b/packages/client/ui-theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-theme",
   "description": "Theme plugin: Host bootstrap for the pre-plugin palette; DOM-free ThemeRuntime for light/dark/system state; --dsw-* token styles and Appearance settings row",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-tool/package.json
+++ b/packages/client/ui-tool/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-tool",
   "description": "Client Tool call-tree renderer and keyed per-tool presentation slot",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-trajectory/package.json
+++ b/packages/client/ui-trajectory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-trajectory",
   "description": "Trajectory event ledger with an interactive timing overview: pure-consumer plugin registering into the conversation ViewMap (no service)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-user-questions/package.json
+++ b/packages/client/ui-user-questions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-user-questions",
   "description": "Web ask_user_question feature: host tool mount plus composer-takeover question UI",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-workflow-run/package.json
+++ b/packages/client/ui-workflow-run/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-workflow-run",
   "description": "Durable workflow-run Conversation Node and nested member disclosure for alego web",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-workspace/package.json
+++ b/packages/client/ui-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-workspace",
   "description": "Workspace picker plugin: one WorkspacePicker registered into the sidebar and empty-state workspace slots",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/web/package.json
+++ b/packages/client/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-web",
   "description": "Web boot kernel: static module table, Cordis loader, framework-free boot page, and UI-renderer handoff",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/code-runtime/code-runtime-python/package.json
+++ b/packages/code-runtime/code-runtime-python/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-code-runtime-python",
   "description": "CPython subprocess implementation of the Alego code-execution seam",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/code-runtime/code-runtime-worker-thread/package.json
+++ b/packages/code-runtime/code-runtime-worker-thread/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-code-runtime-worker-thread",
   "description": "Worker-thread implementation of the Alego code-execution seam",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/code-runtime/code-runtime/package.json
+++ b/packages/code-runtime/code-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-code-runtime",
   "description": "Abstract code-execution seam (ctx.codeRuntime) for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/compaction/command-compact/package.json
+++ b/packages/compaction/command-compact/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-command-compact",
   "description": "Human-facing slash command for explicit session compaction",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/compaction/compaction-basic/package.json
+++ b/packages/compaction/compaction-basic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-compaction-basic",
   "description": "Token-meter-driven compaction policy and LLM summarization backend for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/compaction/compaction-tool-result-pruner/package.json
+++ b/packages/compaction/compaction-tool-result-pruner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-compaction-tool-result-pruner",
   "description": "Replay-safe model-free head/middle/tail pruning for tool-result surface nodes",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/compaction/compaction/package.json
+++ b/packages/compaction/compaction/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-compaction",
   "description": "Abstract compaction service seam (ctx.compaction) for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/context/agent-instructions/package.json
+++ b/packages/context/agent-instructions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-agent-instructions",
   "description": "Workspace context loader for AGENTS.md/CLAUDE.md instruction files",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/context/file-reference-local/package.json
+++ b/packages/context/file-reference-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-file-reference-local",
   "description": "Local-filesystem ctx.fileReferences provider with bounded fuzzy indexes",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/context/file-reference/package.json
+++ b/packages/context/file-reference/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-file-reference",
   "description": "File-reference discovery contract and shared @file grammar",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/context/session-reference/package.json
+++ b/packages/context/session-reference/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-reference",
   "description": "Cross-session snapshot references and durable untrusted model context (ctx.sessionReferenceResolver)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/context/time-context/package.json
+++ b/packages/context/time-context/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-time-context",
   "description": "Opt-in durable per-step context with the current time and elapsed time",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/context/tmux-context/package.json
+++ b/packages/context/tmux-context/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tmux-context",
   "description": "Opt-in durable per-step context with this agent's tmux pane and window location",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/agent-default-model/package.json
+++ b/packages/core/agent-default-model/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-agent-default-model",
   "description": "Default model selection shared by Agent entry points",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/agent-loop/package.json
+++ b/packages/core/agent-loop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-agent-loop",
   "description": "The concrete agent loop plugin for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/agent-tool-presentation/package.json
+++ b/packages/core/agent-tool-presentation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-agent-tool-presentation",
   "description": "Agent-plane presentation selector: composes one agent's tools as Code Mode, native, or both",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/agent/package.json
+++ b/packages/core/agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-agent",
   "description": "Agent interface, registry, initiator scope, and event vocabulary for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/scope/package.json
+++ b/packages/core/scope/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-scope",
   "description": "Scoped-context registration primitive (scope tags, scope-filtered event dispatch) for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/session/package.json
+++ b/packages/core/session/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session",
   "description": "Event-sourced session store for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/system-prompt/package.json
+++ b/packages/core/system-prompt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-system-prompt",
   "description": "System prompt assembly registry for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/tools/package.json
+++ b/packages/core/tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tools",
   "description": "Tool registry and execution pipeline for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/credentials/authorization/package.json
+++ b/packages/credentials/authorization/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-authorization",
   "description": "Authorization seam (ctx.authorization): plugin-owned flows that obtain a credential through a conversation with the human",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/credentials/credentials-local/package.json
+++ b/packages/credentials/credentials-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-credentials-local",
   "description": "File-backed credentials provider ($ALEGO_HOME/.env under the live process environment) for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/credentials/credentials/package.json
+++ b/packages/credentials/credentials/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-credentials",
   "description": "Abstract credential seam (ctx.credentials): settings carry references to secrets, providers own the values",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/e2b/e2b/package.json
+++ b/packages/e2b/e2b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-e2b",
   "description": "Shared E2B sandbox lifecycle for Alego provider adapters",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/e2b/fs-e2b/package.json
+++ b/packages/e2b/fs-e2b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-fs-e2b",
   "description": "E2B filesystem implementation for Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/e2b/subprocess-e2b/package.json
+++ b/packages/e2b/subprocess-e2b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subprocess-e2b",
   "description": "E2B subprocess implementation for Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/examples/acp-demo/package.json
+++ b/packages/examples/acp-demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-acp-demo",
   "description": "ACP automation server app: agent spine + JSONL persistence + ACP transport, with a JSON-RPC stdio bin",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/examples/agent-spine-demo/package.json
+++ b/packages/examples/agent-spine-demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-agent-spine-demo",
   "description": "The default executor-less/UI-less agent spine with fallback session titles, provider-routed retry, and optional persisted goals",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/examples/jsonrpc-demo/package.json
+++ b/packages/examples/jsonrpc-demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-sdk-jsonrpc-demo",
   "description": "Bin that boots an external Cordis config for the stdio JSON-RPC SDK runtime",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/experimental/agent-team/package.json
+++ b/packages/experimental/agent-team/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-experimental-agent-team",
   "description": "Implicit-root Agent Teams roster, durable peer mailbox, and shared task DAG",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/experimental/tool-agent-team/package.json
+++ b/packages/experimental/tool-agent-team/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-experimental-tool-agent-team",
   "description": "Scoped model-facing Agent Teams tools over ctx.agentTeams",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/extensions/cordis-client-runner/package.json
+++ b/packages/extensions/cordis-client-runner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-cordis-client-runner",
   "description": "Browser half of dynamic dual-half plugin packages: event subscription, closure evaluation, guard facade, and loader entries",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/cordis-host-runner/package.json
+++ b/packages/extensions/cordis-host-runner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-cordis-host-runner",
   "description": "Dynamic package definition registry, host-half sandbox lifecycle, and invoke handler table for model-mounted dual-half packages",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/tool-cordis/package.json
+++ b/packages/extensions/tool-cordis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-cordis",
   "description": "Self-referential cordis toolset: inspect the live runtime, mount and dispose model-written plugins",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/ui-cordis/package.json
+++ b/packages/extensions/ui-cordis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-cordis",
   "description": "Cordis dynamic-plugin definition card: the keyed cordis_define tool row with its run/stop switch",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/feedback/command-feedback/package.json
+++ b/packages/feedback/command-feedback/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-command-feedback",
   "description": "Log-only session feedback producer and human-facing slash command",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/feedback/message-feedback/package.json
+++ b/packages/feedback/message-feedback/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-message-feedback",
   "description": "Lifecycle-bound per-message rating and note sidecar for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fs/fs-local/package.json
+++ b/packages/fs/fs-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-fs-local",
   "description": "Local-filesystem implementation of the Alego filesystem seam (ctx.fs)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fs/fs-observation-policy/package.json
+++ b/packages/fs/fs-observation-policy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-fs-observation-policy",
   "description": "File-context policy plugin for the Alego — observed-state, read-before-edit, and version-guarded write/edit added over the ctx.fs provider seam through the fs/* event gate (no service API)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fs/fs-sandbox/package.json
+++ b/packages/fs/fs-sandbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-fs-sandbox",
   "description": "Sandbox-enforcing implementation of the Alego filesystem seam: fences write/edit by the per-call sandbox mode (read-only denies mutation, workspace-write contains it to the workspace + temp roots) while reads pass through",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fs/fs/package.json
+++ b/packages/fs/fs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-fs",
   "description": "Abstract filesystem capability seam (ctx.fs) for the Alego — vocabulary types, the FileSystem service (text IO + optional version-guarded atomic mutations), and the fs/* policy event vocabulary",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fs/tool-fs-search/package.json
+++ b/packages/fs/tool-fs-search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-fs-search",
   "description": "Model-facing filesystem discovery tools (glob, grep) backed by the packaged ripgrep binary (@vscode/ripgrep)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fs/tool-fs/package.json
+++ b/packages/fs/tool-fs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-fs",
   "description": "Model-facing filesystem tools (read, write, edit) over the Alego filesystem seam (ctx.fs)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fs/tool-str-replace-editor/package.json
+++ b/packages/fs/tool-str-replace-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-str-replace-editor",
   "description": "Model-facing view, create, literal replace, and line insert tool over the Harness filesystem service",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/goal/command-goal/package.json
+++ b/packages/goal/command-goal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-command-goal",
   "description": "Human-facing slash command for persisted same-session goals",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/goal/goal-round-driver/package.json
+++ b/packages/goal/goal-round-driver/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-goal-round-driver",
   "description": "Race-fenced same-session goal-round driver",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/goal/goal/package.json
+++ b/packages/goal/goal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-goal",
   "description": "Event-sourced same-session goal state and lifecycle service for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/goal/tool-goal/package.json
+++ b/packages/goal/tool-goal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-goal",
   "description": "Model-facing same-session goal tools with execution-time authority checks",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/guard/repeat-tool-reminder/package.json
+++ b/packages/guard/repeat-tool-reminder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-repeat-tool-reminder",
   "description": "Repeat-tool-call guard plugin: advisory reminders when an agent loops on identical tool calls",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/guard/timeout-policy/package.json
+++ b/packages/guard/timeout-policy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-call-timeout-policy",
   "description": "Tool-call timeout policy: a tools/execute wrapper that arms a per-tool deadline on exec.signal and returns TOOL_TIMEOUT when it wins",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/hooks/hook-protocol/package.json
+++ b/packages/hooks/hook-protocol/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-hook-protocol",
   "description": "Shared Claude Code / Codex hook wire protocol: matcher engine, stdin/exit-code/stdout codec, multi-hook merge, and hook/* session events",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/hooks/hooks-claude-code/package.json
+++ b/packages/hooks/hooks-claude-code/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-hooks-claude-code",
   "description": "Bridge plugin: run a Claude Code hooks.json / settings hook config on the Alego interception seams",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/hooks/hooks-codex/package.json
+++ b/packages/hooks/hooks-codex/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-hooks-codex",
   "description": "Bridge plugin: run a Codex hooks.json hook config on the Alego interception seams",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/host/apiproxy/package.json
+++ b/packages/host/apiproxy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-host-apiproxy",
   "description": "API gateway: the ApiProxy contract (api/), the fetch carrier pair (fetch/), and the host-side gateway plugin providing ctx.apiProxy",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/host/directory-picker-auto/package.json
+++ b/packages/host/directory-picker-auto/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-host-directory-picker-auto",
   "description": "Adaptive chooser of the directory-picker seam: resolves the host situation at boot and mounts the native or browse backend for the Alego web GUI host",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/host/directory-picker-browse/package.json
+++ b/packages/host/directory-picker-browse/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-host-directory-picker-browse",
   "description": "In-app browsing backend of the directory-picker seam (listing/creation primitives over the host filesystem)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/host/directory-picker-native/package.json
+++ b/packages/host/directory-picker-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-host-directory-picker-native",
   "description": "Native-OS-chooser backend of the directory-picker seam for the Alego web GUI host",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/host/directory-picker/package.json
+++ b/packages/host/directory-picker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-host-directory-picker",
   "description": "Abstract workspace-directory picking seam (ctx.directoryPicker) for the Alego web GUI host",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/host/frontend-static/package.json
+++ b/packages/host/frontend-static/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-host-frontend-static",
   "description": "SPA dist server for the Web shell: owns the webserver fallback seat, serving explicit index entries and static assets with traversal rejection and 404 misses",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/host/plugin-inventory/package.json
+++ b/packages/host/plugin-inventory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-host-plugin-inventory",
   "description": "Read-only Remote projection of current Cordis Loader plugin state",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/host/webserver/package.json
+++ b/packages/host/webserver/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-host-webserver",
   "description": "Web route-registration plugin: HTTP and upgrade routes, index transform taps, and static dist fallback; knows no harness concepts",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/identity/anonymous-user-id/package.json
+++ b/packages/identity/anonymous-user-id/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-anonymous-user-id",
   "description": "Shared anonymous user identity for Alego telemetry and feedback correlation",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/interaction/commands/package.json
+++ b/packages/interaction/commands/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-commands",
   "description": "Plugin-owned human command registry for Alego UIs",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/interaction/permission-presets/package.json
+++ b/packages/interaction/permission-presets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-permission-presets",
   "description": "User-facing permission presets (ctx.permissionPresets) for the Alego: one product-level Permissions select bundling the sandbox-mode and approval-policy knobs, written through to their own session events",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/interaction/tool-ask-user/package.json
+++ b/packages/interaction/tool-ask-user/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-ask-user",
   "description": "Model-facing ask_user_question tool over the ctx.userQuestions seam",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/interaction/user-approval/package.json
+++ b/packages/interaction/user-approval/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-user-approval",
   "description": "User-approval seam (ctx.approval) for the Alego: one-shot permission decisions dispatched to composed answerers over the approval/request waterfall, fail-closed by default",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/interaction/user-questions/package.json
+++ b/packages/interaction/user-questions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-user-questions",
   "description": "Abstract user-questions seam (ctx.userQuestions) for asking the human during agent runs",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/jobs/jobs-local/package.json
+++ b/packages/jobs/jobs-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-jobs-local",
   "description": "Process-local implementation of the Alego background job registry seam",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/jobs/jobs/package.json
+++ b/packages/jobs/jobs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-jobs",
   "description": "Background job registry (ctx.jobs) for the Alego — shared ids, owner isolation, polling, cancellation, and completion listeners for long-running tool work",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/jobs/tool-jobs/package.json
+++ b/packages/jobs/tool-jobs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-jobs",
   "description": "Model-facing background job control tools (job_output, job_list, job_kill) over the ctx.jobs registry",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/llm/llm-deepseek/package.json
+++ b/packages/llm/llm-deepseek/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-llm-deepseek",
   "description": "DeepSeek chat-completions adapter for the Alego LLM seam",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/llm/llm-pi-ai/package.json
+++ b/packages/llm/llm-pi-ai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-llm-pi-ai",
   "description": "pi-ai-backed DeepSeek adapter for the Alego LLM seam (design-verification twin of alego-llm-deepseek)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/llm/llm-retry/package.json
+++ b/packages/llm/llm-retry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-llm-retry",
   "description": "Provider-routed LLM request retry policy for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/llm/llm/package.json
+++ b/packages/llm/llm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-llm",
   "description": "Provider-neutral LLM service interface for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/llm/token-meter/package.json
+++ b/packages/llm/token-meter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-token-meter",
   "description": "Replay-aware token measurement service (ctx.tokenMeter) for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/lsp/lsp-stdio/package.json
+++ b/packages/lsp/lsp-stdio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-lsp-stdio",
   "description": "Generic stdio language-server provider for the Alego LSP capability seam (ctx.lsp) — spawns configured servers, translates JSON-RPC, and serves transient-open goToDefinition/findReferences/goToImplementation/hover queries in the host filesystem namespace",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/lsp/lsp/package.json
+++ b/packages/lsp/lsp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-lsp",
   "description": "Abstract LSP capability seam (ctx.lsp) for the Alego — language-server provider registry keyed by branded id and extension mapping, order-independent per-query selection, normalized definition/references/implementation/hover requests and results, and the LspError taxonomy",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/lsp/tool-lsp/package.json
+++ b/packages/lsp/tool-lsp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-lsp",
   "description": "Model-facing lsp tool over the Alego LSP capability seam (ctx.lsp) — one read-only tool with goToDefinition/findReferences/goToImplementation/hover operations, one-based UTF-16 cursor coordinates, bounded location rendering, and hover normalization",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp/mcp-client/package.json
+++ b/packages/mcp/mcp-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-mcp-client",
   "description": "MCP client bridge: connects to MCP servers and registers their tools on ctx.tools",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plan/plan-mode/package.json
+++ b/packages/plan/plan-mode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-plan-mode",
   "description": "Logged per-agent plan mode with deployment guidance, a direct slash command, and a user-reviewed exit",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/preset/agent-presets/package.json
+++ b/packages/preset/agent-presets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-agent-presets",
   "description": "Per-session agent composition from preset cordis.yml files for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/preset/persona/package.json
+++ b/packages/preset/persona/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-persona",
   "description": "Composition-authored deployment persona section for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/runtime-diagnostics/invariants/package.json
+++ b/packages/runtime-diagnostics/invariants/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-invariants",
   "description": "Registry service for package-owned Alego runtime invariants",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sandbox/sandbox-local/package.json
+++ b/packages/sandbox/sandbox-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-sandbox-local",
   "description": "Local process-sandbox backends for the Alego sandbox seam: bwrap, the npm-distributed landlock-run launcher, macOS Seatbelt, or the Windows ACL restricted-token runner — functionally probed, fail-closed",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sandbox/sandbox-policy/package.json
+++ b/packages/sandbox/sandbox-policy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-sandbox-policy",
   "description": "Per-call sandbox policy resolver and current model context: deployment fallbacks plus each session's mode and workspace root, shared by every enforcing capability family",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sandbox/sandbox-windows-acl/package.json
+++ b/packages/sandbox/sandbox-windows-acl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-sandbox-windows-acl",
   "description": "Windows ACL write-restriction sandbox backend (restricted-token spawn with capability-SID write allowlist) for the Alego sandbox seam",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sandbox/sandbox/package.json
+++ b/packages/sandbox/sandbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-sandbox",
   "description": "Abstract process-sandbox seam (ctx.sandbox) for the Alego: same-world confinement vocabulary and the SandboxProvider contract",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/schedule/schedule/package.json
+++ b/packages/schedule/schedule/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-schedule",
   "description": "Agent-scoped durable after, at, and fixed-rate reminders over the session event log",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sdk/client/package.json
+++ b/packages/sdk/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-sdk-client",
   "description": "TypeScript client SDK for driving an Alego runtime subprocess over stdio JSON-RPC: the Alego high-level turns API and the lower-level HarnessClient",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sdk/protocol/package.json
+++ b/packages/sdk/protocol/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-sdk-protocol",
   "description": "Shared wire protocol for the Alego SDK runtime: the newline-delimited JSON-RPC stdio transport and the named request, result, and notification types spoken between the runtime server and SDK clients",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sdk/server/package.json
+++ b/packages/sdk/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-sdk-jsonrpc-server",
   "description": "Stdio JSON-RPC server plugin for out-of-process Alego SDK clients",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session-query/session-log-export/package.json
+++ b/packages/session-query/session-log-export/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-log-export",
   "description": "Web Session-log export command and shared download dialog",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": { "access": "public" },
   "repository": {
     "type": "git",

--- a/packages/session-query/session-query-sqlite/package.json
+++ b/packages/session-query/session-query-sqlite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-query-sqlite",
   "description": "Concrete ctx.sessionQuery backend with SQLite FTS5 search",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session-query/session-query/package.json
+++ b/packages/session-query/session-query/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-query",
   "description": "Combined session query service contract with concrete reads, traces, and filters",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session-query/tool-session-query/package.json
+++ b/packages/session-query/tool-session-query/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-session-query",
   "description": "Workspace-authorized model-facing session history search, trace, and event read tools",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-checkpoint-policy/package.json
+++ b/packages/session/session-checkpoint-policy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-checkpoint-policy",
   "description": "Semantic session durability checkpoints before model requests and tool side effects",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-persistence-jsonl/package.json
+++ b/packages/session/session-persistence-jsonl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-persistence-jsonl",
   "description": "JSONL durable session persistence backend for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-persistence-sqlite/package.json
+++ b/packages/session/session-persistence-sqlite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-persistence-sqlite",
   "description": "SQLite durable session persistence with physical chunk-row packing",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-persistence/package.json
+++ b/packages/session/session-persistence/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-persistence",
   "description": "Abstract durable session persistence seam (ctx.sessionPersistence) for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-projection-cache/package.json
+++ b/packages/session/session-projection-cache/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-projection-cache",
   "description": "Persisted projection cache (ctx.sessionProjectionCache): durable per-session projection checkpoints over the domain data form, throttled write-behind, and the cold-read ladder (cache row + persistence tail replay)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-projection/package.json
+++ b/packages/session/session-projection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-projection",
   "description": "Session-projection seam: the merge-extensible projection type table, the provider contract, and the ctx.sessionProjections registry serving whole current values of log-derived per-session state",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-stats/package.json
+++ b/packages/session/session-stats/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-stats",
   "description": "Whole-log conversation counts and wall times projection (sessionStats) for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-telemetry-otel/package.json
+++ b/packages/session/session-telemetry-otel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-telemetry-otel",
   "description": "OpenTelemetry backend for the Alego telemetry seam: hands captured session records to the OTel JS SDK's log pipeline",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-telemetry/package.json
+++ b/packages/session/session-telemetry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-telemetry",
   "description": "SessionTelemetryBackend seam for the Alego: session-event capture, projection, redaction, and handoff to a reporting backend",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-title-all-prompts-llm/package.json
+++ b/packages/session/session-title-all-prompts-llm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-title-all-prompts-llm",
   "description": "All-user-messages LLM provider plugin for Alego session titles",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-title-first-prompt-llm/package.json
+++ b/packages/session/session-title-first-prompt-llm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-title-first-prompt-llm",
   "description": "First-message LLM provider plugin for Alego session titles",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-title-llm/package.json
+++ b/packages/session/session-title-llm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-title-llm",
   "description": "Shared LLM generation policy for Alego session-title providers",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-title/package.json
+++ b/packages/session/session-title/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-title",
   "description": "Log-backed session title service and provider registry for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/settings/settings-file/package.json
+++ b/packages/settings/settings-file/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-settings-file",
   "description": "File-backed settings provider (settings.yaml) for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/settings/settings/package.json
+++ b/packages/settings/settings/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-settings",
   "description": "Abstract user-settings seam (ctx.settings) for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/bash-local/package.json
+++ b/packages/shell/bash-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-bash-local",
   "description": "Local-subprocess implementation of the Alego bash executor seam",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/bash-sandbox/package.json
+++ b/packages/shell/bash-sandbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-bash-sandbox",
   "description": "Sandbox-consuming implementation of the Alego bash executor seam (confines every command via ctx.sandbox, reports denial/enforcement result facts)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/pwsh-local/package.json
+++ b/packages/shell/pwsh-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-pwsh-local",
   "description": "Local PowerShell implementation of the Alego bash executor seam",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/pwsh-sandbox/package.json
+++ b/packages/shell/pwsh-sandbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-pwsh-sandbox",
   "description": "Sandbox-consuming implementation of the Alego PowerShell executor seam (confines every command via ctx.sandbox, reports denial/enforcement result facts)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/shell-env/package.json
+++ b/packages/shell/shell-env/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-shell-env",
   "description": "Tool-independent managed ALEGO_* shell environment registry",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/shell/package.json
+++ b/packages/shell/shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-shell",
   "description": "Abstract bash executor seam (ctx.shell) for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/tool-bash-persistent/package.json
+++ b/packages/shell/tool-bash-persistent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-bash-persistent",
   "description": "Model-facing owner-scoped persistent Bash tool backed by the Harness PTY service",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/tool-bash/package.json
+++ b/packages/shell/tool-bash/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-bash",
   "description": "Model-facing bash tool with optional generic background-job and sandbox-escalation support",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/tool-pwsh-persistent/package.json
+++ b/packages/shell/tool-pwsh-persistent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-pwsh-persistent",
   "description": "Model-facing owner-scoped persistent PowerShell tool backed by the Harness PTY service",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/tool-pwsh/package.json
+++ b/packages/shell/tool-pwsh/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-pwsh",
   "description": "Model-facing pwsh tool over the bash executor seam",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/skill/skill-badge/package.json
+++ b/packages/skill/skill-badge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-skill-badge",
   "description": "Bundled alego badge skill provider for Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/skill/skill-filesystem/package.json
+++ b/packages/skill/skill-filesystem/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-skill-filesystem",
   "description": "Local filesystem skill provider for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/skill/skill/package.json
+++ b/packages/skill/skill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-skill",
   "description": "Agent skill provider registry for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/skill/tool-skill/package.json
+++ b/packages/skill/tool-skill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-skill",
   "description": "Model-facing skill loading tool for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/spill/spill-local/package.json
+++ b/packages/spill/spill-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-spill-local",
   "description": "Local-filesystem implementation of the Alego spill storage seam (private session-scoped files)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/spill/spill-policy/package.json
+++ b/packages/spill/spill-policy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-spill-policy",
   "description": "Tool-result spill policy for the Alego — replaces oversized plain-text tool results with a retained preview plus a spill-file path (no service API)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/spill/spill/package.json
+++ b/packages/spill/spill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-spill",
   "description": "Abstract spill storage seam (ctx.spillStore) for the Alego — save oversized tool text and return a retrieval locator",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/storage/storage-domain/package.json
+++ b/packages/storage/storage-domain/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-storage-domain",
   "description": "Domain data form (ctx.storage.domain): schema-validated, event-emitting KV domains over storage backends for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/storage/storage-json/package.json
+++ b/packages/storage/storage-json/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-storage-json",
   "description": "JSON file KV storage backend for the Alego storage hub",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/storage/storage-sqlite/package.json
+++ b/packages/storage/storage-sqlite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-storage-sqlite",
   "description": "SQLite storage backend (kv facet) for the Alego storage hub",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/storage/storage/package.json
+++ b/packages/storage/storage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-storage",
   "description": "Storage hub (ctx.storage): named backend registry plus mounted data-form facilities for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/subagent-acp/package.json
+++ b/packages/subagent/subagent-acp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subagent-acp",
   "description": "Out-of-process ACP subagent backend: drives a child agent in a spawned subprocess over the Agent Client Protocol",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/subagent-alego-sdk/package.json
+++ b/packages/subagent/subagent-alego-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subagent-alego-sdk",
   "description": "Out-of-process SDK subagent backend: drives a child Alego runtime subprocess over stdio JSON-RPC through the TypeScript SDK client",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/subagent-claude-code/package.json
+++ b/packages/subagent/subagent-claude-code/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subagent-claude-code",
   "description": "One-shot Claude Code subagent provider over the official Agent SDK",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/subagent-codex/package.json
+++ b/packages/subagent/subagent-codex/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subagent-codex",
   "description": "One-shot Codex subagent provider over the official app-server protocol",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/subagent-fork-in-process/package.json
+++ b/packages/subagent/subagent-fork-in-process/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subagent-fork-in-process",
   "description": "In-process fork subagent backend: runs a child agent seeded with a prefix of the parent's log",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/subagent-in-process-driver/package.json
+++ b/packages/subagent/subagent-in-process-driver/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subagent-in-process-driver",
   "description": "Shared in-process subagent run driver: drives a child agent on ctx.agents (used by the spawn and fork backends)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/subagent-spawn-in-process/package.json
+++ b/packages/subagent/subagent-spawn-in-process/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subagent-spawn-in-process",
   "description": "In-process spawn subagent backend: runs a fresh child agent on ctx.agents",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/subagent/package.json
+++ b/packages/subagent/subagent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subagent",
   "description": "Abstract subagent seam (ctx.subagents): named-provider registry for delegating to child agents",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/tool-subagent-control/package.json
+++ b/packages/subagent/tool-subagent-control/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-subagent-control",
   "description": "Globally named send_message, interrupt_agent, and list_agents tools over ctx.subagents continuations",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/tool-subagent-report/package.json
+++ b/packages/subagent/tool-subagent-report/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-subagent-report",
   "description": "Child-scoped report tool over ctx.subagents continuations",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/tool-subagent/package.json
+++ b/packages/subagent/tool-subagent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-subagent",
   "description": "Model-facing subagent delegation tool over the ctx.subagents seam",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subprocess/subprocess-local/package.json
+++ b/packages/subprocess/subprocess-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subprocess-local",
   "description": "Local-subprocess implementation of the Alego subprocess seam",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subprocess/subprocess/package.json
+++ b/packages/subprocess/subprocess/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subprocess",
   "description": "Subprocess seam (ctx.subprocess) for the Alego — managed process groups, bounded spill-backed output, and escalated kills behind one abstract service",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/terminal/terminal-bash/package.json
+++ b/packages/terminal/terminal-bash/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-terminal-bash",
   "description": "Persistent shell PTY backend over the Alego subprocess terminal primitive",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/terminal/terminal/package.json
+++ b/packages/terminal/terminal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-terminal",
   "description": "Persistent PTY session seam for the Alego — owner-scoped ids, backend registry, interactive sends, reads, signals, and awaited cleanup",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/terminal/tool-terminal/package.json
+++ b/packages/terminal/tool-terminal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-terminal",
   "description": "Six model-facing persistent PTY tools with owner isolation and generic background-job integration",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/test-support/acp-snapshot/package.json
+++ b/packages/test-support/acp-snapshot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-acp-snapshot",
   "description": "ACP test kit: shared subprocess launcher, snapshot scenario harness, expected-output normalizers, and suite factory",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/test-support/agent-loop-testkit/package.json
+++ b/packages/test-support/agent-loop-testkit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-agent-loop-testkit",
   "description": "Shared prerequisite mounting for tests that exercise the concrete agent loop",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/test-support/client-runtime/package.json
+++ b/packages/test-support/client-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-test-runtime",
   "description": "jsdom slot test runtime: real Cordis Context + SlotRegistry + UI renderer with test-owned session/workspace doubles for feature specs",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/test-support/llm-mock-server/package.json
+++ b/packages/test-support/llm-mock-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-llm-mock-server",
   "description": "Scriptable OpenAI-compatible HTTP/SSE fault server for LLM recovery tests",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/test-support/llm-replay/package.json
+++ b/packages/test-support/llm-replay/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-llm-replay",
   "description": "Replay LLM plugin: short-circuits llm/stream with model chunks reconstructed from a recorded session JSONL (keyless snapshot tests)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/test-support/loader-smoke/package.json
+++ b/packages/test-support/loader-smoke/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-loader-smoke",
   "description": "Shared subprocess and direct-agent harness for keyless real-Loader example smoke tests",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/todo/tool-todo/package.json
+++ b/packages/todo/tool-todo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-todo",
   "description": "Model-facing todo_write tool over the Alego event-sourced session log",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/typert/generator/package.json
+++ b/packages/typert/generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-typert-generator",
   "description": "TypeScript project analyzer and model-driven Typert artifact generator",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/typert/loader/package.json
+++ b/packages/typert/loader/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-typert-loader",
   "description": "Loader integration for generated Typert package contributions",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/typert/protocol/package.json
+++ b/packages/typert/protocol/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-typert-protocol",
   "description": "Compiler-independent Remote metadata and Typert provider protocols",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/typert/registry/package.json
+++ b/packages/typert/registry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-typert-registry",
   "description": "Runtime registry for generated package reflection and Zod schemas",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/util/atomic-write/package.json
+++ b/packages/util/atomic-write/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-atomic-write",
   "description": "Zero-dependency atomic file replacement: exclusive-create random-suffix temp + rename carrying the caller-stated permissions (writeFileAtomic)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/util/brand/package.json
+++ b/packages/util/brand/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-brand",
   "description": "Type-only Branded<B> nominal-typing primitive for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/util/home-paths/package.json
+++ b/packages/util/home-paths/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-home-paths",
   "description": "Shared filesystem path helpers for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/util/launch-environment/package.json
+++ b/packages/util/launch-environment/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-launch-environment",
   "description": "Immutable Alego launch environment that records which layer supplied each value",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/util/native-command/package.json
+++ b/packages/util/native-command/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-native-command",
   "description": "Zero-dependency no-shell execFile runner for host-native OS integrations: utf8 stdio capture, abort propagation, Windows hide",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/util/output-retention/package.json
+++ b/packages/util/output-retention/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-output-retention",
   "description": "Zero-dependency bounded-retention primitive: ItemRetainer/TextRetainer + neutral notice helpers (what did we keep, what did we omit)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/util/timeout/package.json
+++ b/packages/util/timeout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-timeout",
   "description": "Zero-dependency timeout/deadline primitive: clampTimeout, deadline, timeoutOf, TimeoutReason (timing + classification only, no termination)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web/tool-web/package.json
+++ b/packages/web/tool-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-web",
   "description": "Model-facing web tools (web_search, web_fetch) over the Alego web capability seam (ctx.web)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web/web-fetch-http/package.json
+++ b/packages/web/web-fetch-http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-web-fetch-http",
   "description": "Anonymous public HTTP(S) fetch provider for the Alego web capability seam (ctx.web)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web/web-search-deepseek/package.json
+++ b/packages/web/web-search-deepseek/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-web-search-deepseek",
   "description": "DeepSeek-backed search provider (native web_search via the Anthropic-compatible API) for the Alego web capability seam (ctx.web)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web/web-search-exa/package.json
+++ b/packages/web/web-search-exa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-web-search-exa",
   "description": "Exa-backed search provider for the Alego web capability seam (ctx.web)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web/web-search-perplexity/package.json
+++ b/packages/web/web-search-perplexity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-web-search-perplexity",
   "description": "Perplexity-backed search provider for the Alego web capability seam (ctx.web)",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web/web/package.json
+++ b/packages/web/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-web",
   "description": "Abstract web access capability seam (ctx.web) for the Alego — search/fetch provider registry, registration-order-independent selection, request/result vocabulary, and the WebError taxonomy",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/workflow/tool-ralph/package.json
+++ b/packages/workflow/tool-ralph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-ralph",
   "description": "Model-facing fresh-agent Ralph loop over the workflow and subagent seams",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/workflow/tool-workflow/package.json
+++ b/packages/workflow/tool-workflow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-workflow",
   "description": "Model-facing workflow tool: run a JavaScript orchestration script over ctx.workflowEngine",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/workflow/workflow-worker-thread/package.json
+++ b/packages/workflow/workflow-worker-thread/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-workflow-worker-thread",
   "description": "worker-thread workflow engine: executes model-written orchestration scripts off the host event loop, bridging agent() calls back to ctx.subagents",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/workflow/workflow/package.json
+++ b/packages/workflow/workflow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-workflow",
   "description": "Workflow capability seam: ctx.workflowEngine service, run vocabulary, and workflow/* events",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/workspace/workspace/package.json
+++ b/packages/workspace/workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-workspace",
   "description": "Workspace entity registry (ctx.workspaceRegistry): durable workspace records with validated session attachment over the domain data form for the Alego",
-  "version": "0.1.1-rc.2",
+  "version": "0.1.1",
   "publishConfig": {
     "access": "public"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,24 +159,9 @@ importers:
       '@singula-ai/alego-compaction-tool-result-pruner':
         specifier: workspace:^
         version: link:../../packages/compaction/compaction-tool-result-pruner
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../vendor/cordis
       '@singula-ai/alego-cordis-client-runner':
         specifier: workspace:^
         version: link:../../packages/extensions/cordis-client-runner
-      '@singula-ai/cordis-plugin-hmr':
-        specifier: workspace:^
-        version: link:../../vendor/hmr
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:^
-        version: link:../../vendor/include
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../vendor/loader
-      '@singula-ai/cordis-plugin-timer':
-        specifier: workspace:^
-        version: link:../../vendor/timer
       '@singula-ai/alego-fs-local':
         specifier: workspace:^
         version: link:../../packages/fs/fs-local
@@ -303,6 +288,21 @@ importers:
       '@singula-ai/alego-workflow-worker-thread':
         specifier: workspace:^
         version: link:../../packages/workflow/workflow-worker-thread
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../vendor/cordis
+      '@singula-ai/cordis-plugin-hmr':
+        specifier: workspace:^
+        version: link:../../vendor/hmr
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:^
+        version: link:../../vendor/include
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../vendor/loader
+      '@singula-ai/cordis-plugin-timer':
+        specifier: workspace:^
+        version: link:../../vendor/timer
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -373,12 +373,12 @@ importers:
       '@singula-ai/alego-cmdline':
         specifier: workspace:^
         version: link:../../packages/boot/cmdline
-      '@singula-ai/cordis-plugin-group':
-        specifier: workspace:^
-        version: link:../../vendor/group
       '@singula-ai/alego-pwsh-local':
         specifier: workspace:^
         version: link:../../packages/shell/pwsh-local
+      '@singula-ai/cordis-plugin-group':
+        specifier: workspace:^
+        version: link:../../vendor/group
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
@@ -466,18 +466,6 @@ importers:
       '@singula-ai/alego-cordis-host-runner':
         specifier: workspace:*
         version: link:../packages/extensions/cordis-host-runner
-      '@singula-ai/cordis-plugin-hmr':
-        specifier: workspace:*
-        version: link:../vendor/hmr
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:*
-        version: link:../vendor/include
-      '@singula-ai/cordis-plugin-logger-console':
-        specifier: workspace:*
-        version: link:../vendor/logger-console
-      '@singula-ai/cordis-plugin-timer':
-        specifier: workspace:*
-        version: link:../vendor/timer
       '@singula-ai/alego-credentials-local':
         specifier: workspace:*
         version: link:../packages/credentials/credentials-local
@@ -562,9 +550,6 @@ importers:
       '@singula-ai/alego-sandbox-policy':
         specifier: workspace:^
         version: link:../packages/sandbox/sandbox-policy
-      '@singula-ai/schemastery':
-        specifier: link:../vendor/schemastery
-        version: link:../vendor/schemastery
       '@singula-ai/alego-scope':
         specifier: workspace:*
         version: link:../packages/core/scope
@@ -751,6 +736,21 @@ importers:
       '@singula-ai/alego-workflow-worker-thread':
         specifier: workspace:*
         version: link:../packages/workflow/workflow-worker-thread
+      '@singula-ai/cordis-plugin-hmr':
+        specifier: workspace:*
+        version: link:../vendor/hmr
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:*
+        version: link:../vendor/include
+      '@singula-ai/cordis-plugin-logger-console':
+        specifier: workspace:*
+        version: link:../vendor/logger-console
+      '@singula-ai/cordis-plugin-timer':
+        specifier: workspace:*
+        version: link:../vendor/timer
+      '@singula-ai/schemastery':
+        specifier: link:../vendor/schemastery
+        version: link:../vendor/schemastery
 
   native/landlock-run:
     devDependencies:
@@ -801,9 +801,6 @@ importers:
       '@singula-ai/alego-attachment':
         specifier: workspace:^
         version: link:../../attachment/attachment
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -819,6 +816,9 @@ importers:
       '@singula-ai/alego-user-approval':
         specifier: workspace:^
         version: link:../../interaction/user-approval
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/api/gateway:
     dependencies:
@@ -829,9 +829,6 @@ importers:
       '@singula-ai/alego-client-connection':
         specifier: workspace:^
         version: link:../../client/connection
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-host-webserver':
         specifier: workspace:^
         version: link:../../host/webserver
@@ -841,6 +838,9 @@ importers:
       '@singula-ai/alego-typert-registry':
         specifier: workspace:^
         version: link:../../typert/registry
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -863,9 +863,6 @@ importers:
       '@singula-ai/alego-commands':
         specifier: workspace:^
         version: link:../../interaction/commands
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-cordis-host-runner':
         specifier: workspace:^
         version: link:../../extensions/cordis-host-runner
@@ -905,18 +902,21 @@ importers:
       '@singula-ai/alego-typert-registry':
         specifier: workspace:^
         version: link:../../typert/registry
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/attachment/attachment:
     devDependencies:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/attachment/attachment-local:
     dependencies:
@@ -930,15 +930,15 @@ importers:
       '@singula-ai/alego-attachment':
         specifier: workspace:^
         version: link:../attachment
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-home-paths':
         specifier: workspace:^
         version: link:../../util/home-paths
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/boot/app-boot:
     dependencies:
@@ -946,6 +946,18 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0
     devDependencies:
+      '@singula-ai/alego-home-paths':
+        specifier: workspace:^
+        version: link:../../util/home-paths
+      '@singula-ai/alego-invariants':
+        specifier: workspace:^
+        version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/alego-launch-environment':
+        specifier: workspace:^
+        version: link:../../util/launch-environment
+      '@singula-ai/alego-system-prompt':
+        specifier: workspace:^
+        version: link:../../core/system-prompt
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
@@ -964,24 +976,15 @@ importers:
       '@singula-ai/cordis-plugin-timer':
         specifier: workspace:^
         version: link:../../../vendor/timer
-      '@singula-ai/alego-home-paths':
-        specifier: workspace:^
-        version: link:../../util/home-paths
-      '@singula-ai/alego-invariants':
-        specifier: workspace:^
-        version: link:../../runtime-diagnostics/invariants
-      '@singula-ai/alego-launch-environment':
-        specifier: workspace:^
-        version: link:../../util/launch-environment
-      '@singula-ai/alego-system-prompt':
-        specifier: workspace:^
-        version: link:../../core/system-prompt
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
 
   packages/boot/cmdline:
     devDependencies:
+      '@singula-ai/alego-invariants':
+        specifier: workspace:^
+        version: link:../../runtime-diagnostics/invariants
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
@@ -991,9 +994,6 @@ importers:
       '@singula-ai/cordis-plugin-loader':
         specifier: workspace:^
         version: link:../../../vendor/loader
-      '@singula-ai/alego-invariants':
-        specifier: workspace:^
-        version: link:../../runtime-diagnostics/invariants
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -1039,12 +1039,6 @@ importers:
       '@singula-ai/alego-compaction-tool-result-pruner':
         specifier: workspace:^
         version: link:../../compaction/compaction-tool-result-pruner
-      '@singula-ai/cordis-plugin-hmr':
-        specifier: workspace:^
-        version: link:../../../vendor/hmr
-      '@singula-ai/cordis-plugin-timer':
-        specifier: workspace:^
-        version: link:../../../vendor/timer
       '@singula-ai/alego-credentials-local':
         specifier: workspace:^
         version: link:../../credentials/credentials-local
@@ -1231,13 +1225,19 @@ importers:
       '@singula-ai/alego-workflow-worker-thread':
         specifier: workspace:^
         version: link:../../workflow/workflow-worker-thread
-    devDependencies:
-      '@singula-ai/cordis':
+      '@singula-ai/cordis-plugin-hmr':
         specifier: workspace:^
-        version: link:../../../vendor/cordis
+        version: link:../../../vendor/hmr
+      '@singula-ai/cordis-plugin-timer':
+        specifier: workspace:^
+        version: link:../../../vendor/timer
+    devDependencies:
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/bundle/headless:
     dependencies:
@@ -1260,12 +1260,6 @@ importers:
       '@singula-ai/alego-agent-default-model':
         specifier: workspace:^
         version: link:../../core/agent-default-model
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -1275,6 +1269,12 @@ importers:
       '@singula-ai/alego-session':
         specifier: workspace:^
         version: link:../../core/session
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/bundle/web-app:
     dependencies:
@@ -1446,9 +1446,6 @@ importers:
       '@singula-ai/alego-message-feedback':
         specifier: workspace:^
         version: link:../../feedback/message-feedback
-      '@singula-ai/schemastery':
-        specifier: link:../../../vendor/schemastery
-        version: link:../../../vendor/schemastery
       '@singula-ai/alego-session-log-export':
         specifier: workspace:^
         version: link:../../session-query/session-log-export
@@ -1479,6 +1476,9 @@ importers:
       '@singula-ai/alego-workspace':
         specifier: workspace:^
         version: link:../../workspace/workspace
+      '@singula-ai/schemastery':
+        specifier: link:../../../vendor/schemastery
+        version: link:../../../vendor/schemastery
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -1486,12 +1486,6 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -1501,6 +1495,12 @@ importers:
       '@singula-ai/alego-system-prompt':
         specifier: workspace:^
         version: link:../../core/system-prompt
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/client/connection:
     dependencies:
@@ -1517,9 +1517,6 @@ importers:
       '@singula-ai/alego-commands':
         specifier: workspace:^
         version: link:../../interaction/commands
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-host-apiproxy':
         specifier: workspace:^
         version: link:../../host/apiproxy
@@ -1538,6 +1535,9 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -1551,18 +1551,18 @@ importers:
       '@singula-ai/alego-client-modules':
         specifier: workspace:^
         version: link:../modules
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-host-webserver':
         specifier: workspace:^
         version: link:../../host/webserver
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/client/locale:
     dependencies:
@@ -1591,15 +1591,15 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-settings':
         specifier: workspace:^
         version: link:../../settings/settings
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -1609,18 +1609,18 @@ importers:
 
   packages/client/modules:
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-host-webserver':
         specifier: workspace:^
         version: link:../../host/webserver
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/client/runtime:
     dependencies:
@@ -1649,9 +1649,6 @@ importers:
       '@singula-ai/alego-commands':
         specifier: workspace:^
         version: link:../../interaction/commands
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-host-apiproxy':
         specifier: workspace:^
         version: link:../../host/apiproxy
@@ -1685,6 +1682,9 @@ importers:
       '@singula-ai/alego-typert-registry':
         specifier: workspace:^
         version: link:../../typert/registry
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -1721,12 +1721,12 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -1755,12 +1755,12 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -1788,12 +1788,12 @@ importers:
       '@singula-ai/alego-client-ui-sidebar':
         specifier: workspace:^
         version: link:../ui-sidebar
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@testing-library/react':
         specifier: ^16.1.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1843,12 +1843,12 @@ importers:
       '@singula-ai/alego-commands':
         specifier: workspace:^
         version: link:../../interaction/commands
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -1910,9 +1910,6 @@ importers:
       '@singula-ai/alego-compaction':
         specifier: workspace:^
         version: link:../../compaction/compaction
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-goal':
         specifier: workspace:^
         version: link:../../goal/goal
@@ -1946,6 +1943,9 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -1976,15 +1976,15 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-system-prompt':
         specifier: workspace:^
         version: link:../../core/system-prompt
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -2016,12 +2016,12 @@ importers:
       '@singula-ai/alego-client-ui-workspace':
         specifier: workspace:^
         version: link:../ui-workspace
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@testing-library/react':
         specifier: ^16.1.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2043,12 +2043,12 @@ importers:
       '@singula-ai/alego-client-ui-workspace':
         specifier: workspace:^
         version: link:../ui-workspace
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@testing-library/react':
         specifier: ^16.1.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2088,9 +2088,6 @@ importers:
       '@singula-ai/alego-commands':
         specifier: workspace:^
         version: link:../../interaction/commands
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-goal':
         specifier: workspace:^
         version: link:../../goal/goal
@@ -2103,6 +2100,9 @@ importers:
       '@singula-ai/alego-typert-protocol':
         specifier: workspace:^
         version: link:../../typert/protocol
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@testing-library/react':
         specifier: ^16.1.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2137,15 +2137,15 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-file-reference':
         specifier: workspace:^
         version: link:../../context/file-reference
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -2173,12 +2173,12 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -2200,12 +2200,12 @@ importers:
       '@singula-ai/alego-client-ui-theme':
         specifier: workspace:^
         version: link:../ui-theme
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -2239,9 +2239,6 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -2251,6 +2248,9 @@ importers:
       '@singula-ai/alego-typert-protocol':
         specifier: workspace:^
         version: link:../../typert/protocol
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@testing-library/react':
         specifier: ^16.1.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2303,12 +2303,12 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -2348,15 +2348,15 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-permission-presets':
         specifier: workspace:^
         version: link:../../interaction/permission-presets
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -2387,15 +2387,15 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-plan-mode':
         specifier: workspace:^
         version: link:../../plan/plan-mode
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -2466,12 +2466,12 @@ importers:
         specifier: ^4.3.1
         version: 4.3.1
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -2496,9 +2496,6 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-file-reference':
         specifier: workspace:^
         version: link:../../context/file-reference
@@ -2511,6 +2508,9 @@ importers:
       '@singula-ai/alego-typert-protocol':
         specifier: workspace:^
         version: link:../../typert/protocol
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/client/ui-renderer:
     dependencies:
@@ -2527,12 +2527,12 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -2567,15 +2567,15 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-settings':
         specifier: workspace:^
         version: link:../../settings/settings
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -2619,15 +2619,15 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-settings':
         specifier: workspace:^
         version: link:../../settings/settings
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -2661,12 +2661,12 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -2697,12 +2697,12 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@testing-library/react':
         specifier: ^16.1.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2746,12 +2746,12 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -2783,12 +2783,12 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -2825,12 +2825,12 @@ importers:
       '@singula-ai/alego-client-ui-tool':
         specifier: workspace:^
         version: link:../ui-tool
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@testing-library/react':
         specifier: ^16.1.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2846,12 +2846,12 @@ importers:
 
   packages/client/ui-slots:
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -2879,9 +2879,6 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -2891,6 +2888,9 @@ importers:
       '@singula-ai/alego-token-meter':
         specifier: workspace:^
         version: link:../../llm/token-meter
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -2937,9 +2937,6 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-host-webserver':
         specifier: workspace:^
         version: link:../../host/webserver
@@ -2949,6 +2946,9 @@ importers:
       '@singula-ai/alego-settings':
         specifier: workspace:^
         version: link:../../settings/settings
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -2986,12 +2986,12 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@testing-library/react':
         specifier: ^16.1.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3038,15 +3038,15 @@ importers:
       '@singula-ai/alego-compaction':
         specifier: workspace:^
         version: link:../../compaction/compaction
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -3090,9 +3090,6 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -3105,6 +3102,9 @@ importers:
       '@singula-ai/alego-user-questions':
         specifier: workspace:^
         version: link:../../interaction/user-questions
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -3132,9 +3132,6 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -3147,6 +3144,9 @@ importers:
       '@singula-ai/alego-workflow':
         specifier: workspace:^
         version: link:../../workflow/workflow
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -3184,12 +3184,12 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -3211,15 +3211,15 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../ui-slots
+      '@singula-ai/alego-invariants':
+        specifier: workspace:^
+        version: link:../../runtime-diagnostics/invariants
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
       '@singula-ai/cordis-plugin-loader':
         specifier: workspace:^
         version: link:../../../vendor/loader
-      '@singula-ai/alego-invariants':
-        specifier: workspace:^
-        version: link:../../runtime-diagnostics/invariants
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -3238,21 +3238,21 @@ importers:
 
   packages/code-runtime/code-runtime:
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/code-runtime/code-runtime-python:
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/code-runtime/code-runtime-worker-thread:
     dependencies:
@@ -3263,9 +3263,6 @@ importers:
       '@singula-ai/alego-code-runtime':
         specifier: workspace:^
         version: link:../code-runtime
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -3275,6 +3272,9 @@ importers:
       '@singula-ai/alego-timeout':
         specifier: workspace:^
         version: link:../../util/timeout
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/compaction/command-compact:
     devDependencies:
@@ -3287,6 +3287,15 @@ importers:
       '@singula-ai/alego-compaction':
         specifier: workspace:^
         version: link:../compaction
+      '@singula-ai/alego-invariants':
+        specifier: workspace:^
+        version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/alego-llm':
+        specifier: workspace:^
+        version: link:../../llm/llm
+      '@singula-ai/alego-session':
+        specifier: workspace:^
+        version: link:../../core/session
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
@@ -3296,15 +3305,6 @@ importers:
       '@singula-ai/cordis-plugin-loader':
         specifier: workspace:^
         version: link:../../../vendor/loader
-      '@singula-ai/alego-invariants':
-        specifier: workspace:^
-        version: link:../../runtime-diagnostics/invariants
-      '@singula-ai/alego-llm':
-        specifier: workspace:^
-        version: link:../../llm/llm
-      '@singula-ai/alego-session':
-        specifier: workspace:^
-        version: link:../../core/session
 
   packages/compaction/compaction:
     devDependencies:
@@ -3314,9 +3314,6 @@ importers:
       '@singula-ai/alego-commands':
         specifier: workspace:^
         version: link:../../interaction/commands
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -3326,6 +3323,9 @@ importers:
       '@singula-ai/alego-session':
         specifier: workspace:^
         version: link:../../core/session
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/compaction/compaction-basic:
     dependencies:
@@ -3351,15 +3351,6 @@ importers:
       '@singula-ai/alego-compaction-tool-result-pruner':
         specifier: workspace:^
         version: link:../compaction-tool-result-pruner
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:^
-        version: link:../../../vendor/include
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -3378,6 +3369,15 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:^
+        version: link:../../../vendor/include
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/compaction/compaction-tool-result-pruner:
     dependencies:
@@ -3388,15 +3388,6 @@ importers:
       '@singula-ai/alego-compaction':
         specifier: workspace:^
         version: link:../compaction
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:^
-        version: link:../../../vendor/include
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -3409,6 +3400,15 @@ importers:
       '@singula-ai/alego-token-meter':
         specifier: workspace:^
         version: link:../../llm/token-meter
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:^
+        version: link:../../../vendor/include
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/context/agent-instructions:
     dependencies:
@@ -3422,12 +3422,6 @@ importers:
       '@singula-ai/alego-agent-loop':
         specifier: workspace:^
         version: link:../../core/agent-loop
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-fs':
         specifier: workspace:^
         version: link:../../fs/fs
@@ -3458,6 +3452,12 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/context/file-reference:
     dependencies:
@@ -3468,15 +3468,15 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-typert-protocol':
         specifier: workspace:^
         version: link:../../typert/protocol
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/context/file-reference-local:
     dependencies:
@@ -3487,9 +3487,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-file-reference':
         specifier: workspace:^
         version: link:../file-reference
@@ -3502,6 +3499,9 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/context/session-reference:
     dependencies:
@@ -3518,9 +3518,6 @@ importers:
       '@singula-ai/alego-compaction':
         specifier: workspace:^
         version: link:../../compaction/compaction
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -3539,6 +3536,9 @@ importers:
       '@singula-ai/alego-typert-protocol':
         specifier: workspace:^
         version: link:../../typert/protocol
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/context/time-context:
     dependencies:
@@ -3555,9 +3555,6 @@ importers:
       '@singula-ai/alego-agent-loop-testkit':
         specifier: workspace:^
         version: link:../../test-support/agent-loop-testkit
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -3576,6 +3573,9 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/context/tmux-context:
     dependencies:
@@ -3586,9 +3586,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -3604,12 +3601,12 @@ importers:
       '@singula-ai/alego-system-prompt':
         specifier: workspace:^
         version: link:../../core/system-prompt
-
-  packages/core/agent:
-    devDependencies:
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
+
+  packages/core/agent:
+    devDependencies:
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -3631,6 +3628,9 @@ importers:
       '@singula-ai/alego-typert-registry':
         specifier: workspace:^
         version: link:../../typert/registry
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/core/agent-default-model:
     dependencies:
@@ -3641,9 +3641,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -3653,6 +3650,9 @@ importers:
       '@singula-ai/alego-settings':
         specifier: workspace:^
         version: link:../../settings/settings
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/core/agent-loop:
     dependencies:
@@ -3663,9 +3663,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -3693,6 +3690,9 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/core/agent-tool-presentation:
     dependencies:
@@ -3706,9 +3706,6 @@ importers:
       '@singula-ai/alego-code-runtime':
         specifier: workspace:^
         version: link:../../code-runtime/code-runtime
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -3724,24 +3721,24 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../tools
-
-  packages/core/scope:
-    devDependencies:
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
+
+  packages/core/scope:
+    devDependencies:
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/core/session:
     devDependencies:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -3757,6 +3754,9 @@ importers:
       '@singula-ai/alego-typert-registry':
         specifier: workspace:^
         version: link:../../typert/registry
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/core/system-prompt:
     dependencies:
@@ -3764,9 +3764,6 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -3776,6 +3773,9 @@ importers:
       '@singula-ai/alego-scope':
         specifier: workspace:^
         version: link:../scope
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/core/tools:
     dependencies:
@@ -3789,9 +3789,6 @@ importers:
       '@singula-ai/alego-code-runtime':
         specifier: workspace:^
         version: link:../../code-runtime/code-runtime
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -3810,12 +3807,12 @@ importers:
       '@singula-ai/alego-user-approval':
         specifier: workspace:^
         version: link:../../interaction/user-approval
-
-  packages/credentials/authorization:
-    devDependencies:
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
+
+  packages/credentials/authorization:
+    devDependencies:
       '@singula-ai/alego-credentials':
         specifier: workspace:^
         version: link:../credentials
@@ -3825,18 +3822,21 @@ importers:
       '@singula-ai/alego-llm':
         specifier: workspace:^
         version: link:../../llm/llm
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/credentials/credentials:
     devDependencies:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/credentials/credentials-local:
     dependencies:
@@ -3853,9 +3853,6 @@ importers:
       '@singula-ai/alego-atomic-write':
         specifier: workspace:^
         version: link:../../util/atomic-write
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-credentials':
         specifier: workspace:^
         version: link:../credentials
@@ -3868,6 +3865,9 @@ importers:
       '@singula-ai/alego-launch-environment':
         specifier: workspace:^
         version: link:../../util/launch-environment
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/e2b/e2b:
     dependencies:
@@ -3878,9 +3878,6 @@ importers:
         specifier: 2.29.1
         version: 2.29.1
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -3890,12 +3887,12 @@ importers:
       '@singula-ai/alego-sandbox-policy':
         specifier: workspace:^
         version: link:../../sandbox/sandbox-policy
-
-  packages/e2b/fs-e2b:
-    devDependencies:
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
+
+  packages/e2b/fs-e2b:
+    devDependencies:
       '@singula-ai/alego-e2b':
         specifier: workspace:^
         version: link:../e2b
@@ -3905,6 +3902,9 @@ importers:
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/e2b/subprocess-e2b:
     dependencies:
@@ -3912,9 +3912,6 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-e2b':
         specifier: workspace:^
         version: link:../e2b
@@ -3927,6 +3924,9 @@ importers:
       '@singula-ai/alego-timeout':
         specifier: workspace:^
         version: link:../../util/timeout
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/examples/acp-demo:
     dependencies:
@@ -3949,15 +3949,6 @@ importers:
       '@singula-ai/alego-app-boot':
         specifier: workspace:^
         version: link:../../boot/app-boot
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:^
-        version: link:../../../vendor/include
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -3979,6 +3970,15 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:^
+        version: link:../../../vendor/include
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/examples/agent-spine-demo:
     dependencies:
@@ -4001,12 +4001,6 @@ importers:
       '@singula-ai/alego-bash-sandbox':
         specifier: workspace:^
         version: link:../../shell/bash-sandbox
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-timer':
-        specifier: workspace:^
-        version: link:../../../vendor/timer
       '@singula-ai/alego-fs-local':
         specifier: workspace:^
         version: link:../../fs/fs-local
@@ -4040,9 +4034,6 @@ importers:
       '@singula-ai/alego-llm-retry':
         specifier: workspace:^
         version: link:../../llm/llm-retry
-      '@singula-ai/node-addon-landlock-run':
-        specifier: workspace:^
-        version: link:../../../native/landlock-run/packages/entry
       '@singula-ai/alego-sandbox-local':
         specifier: workspace:^
         version: link:../../sandbox/sandbox-local
@@ -4091,6 +4082,15 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-timer':
+        specifier: workspace:^
+        version: link:../../../vendor/timer
+      '@singula-ai/node-addon-landlock-run':
+        specifier: workspace:^
+        version: link:../../../native/landlock-run/packages/entry
 
   packages/examples/jsonrpc-demo:
     dependencies:
@@ -4098,12 +4098,12 @@ importers:
         specifier: workspace:^
         version: link:../../boot/app-boot
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/experimental/agent-team:
     dependencies:
@@ -4126,9 +4126,6 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -4156,6 +4153,9 @@ importers:
       '@singula-ai/alego-subagent-spawn-in-process':
         specifier: workspace:^
         version: link:../../subagent/subagent-spawn-in-process
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/experimental/tool-agent-team:
     dependencies:
@@ -4172,9 +4172,6 @@ importers:
       '@singula-ai/alego-agent-loop-testkit':
         specifier: workspace:^
         version: link:../../test-support/agent-loop-testkit
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-experimental-agent-team':
         specifier: workspace:^
         version: link:../agent-team
@@ -4208,6 +4205,9 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/extensions/cordis-client-runner:
     devDependencies:
@@ -4226,15 +4226,15 @@ importers:
       '@singula-ai/alego-client-ui-theme':
         specifier: workspace:^
         version: link:../../client/ui-theme
+      '@singula-ai/alego-invariants':
+        specifier: workspace:^
+        version: link:../../runtime-diagnostics/invariants
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
       '@singula-ai/cordis-plugin-loader':
         specifier: workspace:^
         version: link:../../../vendor/loader
-      '@singula-ai/alego-invariants':
-        specifier: workspace:^
-        version: link:../../runtime-diagnostics/invariants
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -4257,12 +4257,6 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-timer':
-        specifier: workspace:^
-        version: link:../../../vendor/timer
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -4281,21 +4275,21 @@ importers:
       '@singula-ai/alego-typert-protocol':
         specifier: workspace:^
         version: link:../../typert/protocol
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-timer':
+        specifier: workspace:^
+        version: link:../../../vendor/timer
 
   packages/extensions/tool-cordis:
     devDependencies:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-cordis-host-runner':
         specifier: workspace:^
         version: link:../cordis-host-runner
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -4314,6 +4308,12 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/extensions/ui-cordis:
     devDependencies:
@@ -4344,15 +4344,15 @@ importers:
       '@singula-ai/alego-client-ui-tool':
         specifier: workspace:^
         version: link:../../client/ui-tool
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-cordis-client-runner':
         specifier: workspace:^
         version: link:../cordis-client-runner
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -4371,15 +4371,6 @@ importers:
       '@singula-ai/alego-commands':
         specifier: workspace:^
         version: link:../../interaction/commands
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:^
-        version: link:../../../vendor/include
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -4392,6 +4383,15 @@ importers:
       '@singula-ai/alego-session-telemetry':
         specifier: workspace:^
         version: link:../../session/session-telemetry
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:^
+        version: link:../../../vendor/include
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/feedback/message-feedback:
     dependencies:
@@ -4405,15 +4405,6 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:^
-        version: link:../../../vendor/include
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -4441,15 +4432,21 @@ importers:
       '@singula-ai/alego-typert-protocol':
         specifier: workspace:^
         version: link:../../typert/protocol
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:^
+        version: link:../../../vendor/include
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/fs/fs:
     devDependencies:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -4459,6 +4456,9 @@ importers:
       '@singula-ai/alego-sandbox':
         specifier: workspace:^
         version: link:../../sandbox/sandbox
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/fs/fs-local:
     dependencies:
@@ -4469,9 +4469,6 @@ importers:
         specifier: ^3.1.0
         version: 3.1.1
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-fs':
         specifier: workspace:^
         version: link:../fs
@@ -4481,12 +4478,12 @@ importers:
       '@singula-ai/alego-llm':
         specifier: workspace:^
         version: link:../../llm/llm
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/fs/fs-observation-policy:
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-fs':
         specifier: workspace:^
         version: link:../fs
@@ -4496,12 +4493,12 @@ importers:
       '@singula-ai/alego-llm':
         specifier: workspace:^
         version: link:../../llm/llm
-
-  packages/fs/fs-sandbox:
-    devDependencies:
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
+
+  packages/fs/fs-sandbox:
+    devDependencies:
       '@singula-ai/alego-fs':
         specifier: workspace:^
         version: link:../fs
@@ -4517,6 +4514,9 @@ importers:
       '@singula-ai/alego-sandbox-policy':
         specifier: workspace:^
         version: link:../../sandbox/sandbox-policy
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/fs/tool-fs:
     dependencies:
@@ -4539,9 +4539,6 @@ importers:
       '@singula-ai/alego-attachment':
         specifier: workspace:^
         version: link:../../attachment/attachment
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-fs':
         specifier: workspace:^
         version: link:../fs
@@ -4578,6 +4575,9 @@ importers:
       '@singula-ai/alego-user-approval':
         specifier: workspace:^
         version: link:../../interaction/user-approval
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/fs/tool-fs-search:
     dependencies:
@@ -4591,9 +4591,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -4624,6 +4621,9 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/fs/tool-str-replace-editor:
     dependencies:
@@ -4634,9 +4634,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-fs':
         specifier: workspace:^
         version: link:../fs
@@ -4670,6 +4667,9 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/goal/command-goal:
     devDependencies:
@@ -4679,12 +4679,6 @@ importers:
       '@singula-ai/alego-commands':
         specifier: workspace:^
         version: link:../../interaction/commands
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-goal':
         specifier: workspace:^
         version: link:../goal
@@ -4697,6 +4691,12 @@ importers:
       '@singula-ai/alego-session':
         specifier: workspace:^
         version: link:../../core/session
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/goal/goal:
     dependencies:
@@ -4713,9 +4713,6 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -4737,6 +4734,9 @@ importers:
       '@singula-ai/alego-typert-protocol':
         specifier: workspace:^
         version: link:../../typert/protocol
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/goal/goal-round-driver:
     devDependencies:
@@ -4749,9 +4749,6 @@ importers:
       '@singula-ai/alego-agent-loop-testkit':
         specifier: workspace:^
         version: link:../../test-support/agent-loop-testkit
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-goal':
         specifier: workspace:^
         version: link:../goal
@@ -4770,6 +4767,9 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/goal/tool-goal:
     dependencies:
@@ -4780,12 +4780,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-goal':
         specifier: workspace:^
         version: link:../goal
@@ -4804,6 +4798,12 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/guard/repeat-tool-reminder:
     dependencies:
@@ -4820,9 +4820,6 @@ importers:
       '@singula-ai/alego-agent-loop-testkit':
         specifier: workspace:^
         version: link:../../test-support/agent-loop-testkit
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -4835,12 +4832,12 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
-
-  packages/guard/timeout-policy:
-    devDependencies:
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
+
+  packages/guard/timeout-policy:
+    devDependencies:
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -4853,12 +4850,12 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
-
-  packages/hooks/hook-protocol:
-    devDependencies:
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
+
+  packages/hooks/hook-protocol:
+    devDependencies:
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -4868,6 +4865,9 @@ importers:
       '@singula-ai/alego-shell':
         specifier: workspace:^
         version: link:../../shell/shell
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/hooks/hooks-claude-code:
     dependencies:
@@ -4887,9 +4887,6 @@ importers:
       '@singula-ai/alego-bash-local':
         specifier: workspace:^
         version: link:../../shell/bash-local
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-hook-protocol':
         specifier: workspace:^
         version: link:../hook-protocol
@@ -4920,6 +4917,9 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/hooks/hooks-codex:
     dependencies:
@@ -4939,9 +4939,6 @@ importers:
       '@singula-ai/alego-bash-local':
         specifier: workspace:^
         version: link:../../shell/bash-local
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-hook-protocol':
         specifier: workspace:^
         version: link:../hook-protocol
@@ -4969,6 +4966,9 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/host/apiproxy:
     dependencies:
@@ -5008,9 +5008,6 @@ importers:
       '@singula-ai/alego-native-command':
         specifier: workspace:^
         version: link:../../util/native-command
-      '@singula-ai/schemastery':
-        specifier: link:../../../vendor/schemastery
-        version: link:../../../vendor/schemastery
       '@singula-ai/alego-session':
         specifier: workspace:^
         version: link:../../core/session
@@ -5050,6 +5047,9 @@ importers:
       '@singula-ai/alego-workspace':
         specifier: workspace:^
         version: link:../../workspace/workspace
+      '@singula-ai/schemastery':
+        specifier: link:../../../vendor/schemastery
+        version: link:../../../vendor/schemastery
       fflate:
         specifier: ^0.8.2
         version: 0.8.3
@@ -5060,9 +5060,6 @@ importers:
       '@singula-ai/alego-agent-presets':
         specifier: workspace:^
         version: link:../../preset/agent-presets
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-cordis-host-runner':
         specifier: workspace:^
         version: link:../../extensions/cordis-host-runner
@@ -5081,15 +5078,18 @@ importers:
       '@singula-ai/alego-typert-registry':
         specifier: workspace:^
         version: link:../../typert/registry
-
-  packages/host/directory-picker:
-    devDependencies:
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
+
+  packages/host/directory-picker:
+    devDependencies:
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/host/directory-picker-auto:
     devDependencies:
@@ -5099,15 +5099,6 @@ importers:
       '@singula-ai/alego-client-ui-directory-picker-native':
         specifier: workspace:^
         version: link:../../client/ui-directory-picker-native
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:^
-        version: link:../../../vendor/include
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-host-directory-picker':
         specifier: workspace:^
         version: link:../directory-picker
@@ -5123,6 +5114,15 @@ importers:
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:^
+        version: link:../../../vendor/include
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/host/directory-picker-browse:
     dependencies:
@@ -5133,12 +5133,12 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/host/directory-picker-native:
     dependencies:
@@ -5152,12 +5152,12 @@ importers:
         specifier: ^3.1.0
         version: 3.1.1
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       tsx:
         specifier: ^4.19.2
         version: 4.22.4
@@ -5168,18 +5168,18 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-host-webserver':
         specifier: workspace:^
         version: link:../webserver
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/host/plugin-inventory:
     dependencies:
@@ -5190,18 +5190,18 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-typert-protocol':
         specifier: workspace:^
         version: link:../../typert/protocol
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/host/webserver:
     dependencies:
@@ -5209,27 +5209,27 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/identity/anonymous-user-id:
     devDependencies:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-home-paths':
         specifier: workspace:^
         version: link:../../util/home-paths
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/interaction/commands:
     dependencies:
@@ -5246,9 +5246,6 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -5264,6 +5261,9 @@ importers:
       '@singula-ai/alego-typert-protocol':
         specifier: workspace:^
         version: link:../../typert/protocol
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/interaction/permission-presets:
     dependencies:
@@ -5277,9 +5277,6 @@ importers:
       '@singula-ai/alego-commands':
         specifier: workspace:^
         version: link:../commands
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -5304,15 +5301,15 @@ importers:
       '@singula-ai/alego-user-approval':
         specifier: workspace:^
         version: link:../user-approval
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/interaction/tool-ask-user:
     devDependencies:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -5328,6 +5325,9 @@ importers:
       '@singula-ai/alego-user-questions':
         specifier: workspace:^
         version: link:../user-questions
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/interaction/user-approval:
     dependencies:
@@ -5341,9 +5341,6 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -5359,21 +5356,24 @@ importers:
       '@singula-ai/alego-system-prompt':
         specifier: workspace:^
         version: link:../../core/system-prompt
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/interaction/user-questions:
     devDependencies:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-llm':
         specifier: workspace:^
         version: link:../../llm/llm
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/jobs/jobs:
     devDependencies:
@@ -5383,15 +5383,15 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-session':
         specifier: workspace:^
         version: link:../../core/session
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/jobs/jobs-local:
     dependencies:
@@ -5405,15 +5405,6 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:^
-        version: link:../../../vendor/include
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -5429,6 +5420,15 @@ importers:
       '@singula-ai/alego-timeout':
         specifier: workspace:^
         version: link:../../util/timeout
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:^
+        version: link:../../../vendor/include
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/jobs/tool-jobs:
     dependencies:
@@ -5439,9 +5439,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -5466,6 +5463,9 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/llm/llm:
     dependencies:
@@ -5479,15 +5479,15 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-timeout':
         specifier: workspace:^
         version: link:../../util/timeout
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/llm/llm-deepseek:
     dependencies:
@@ -5510,9 +5510,6 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-credentials':
         specifier: workspace:^
         version: link:../../credentials/credentials
@@ -5534,15 +5531,18 @@ importers:
       '@singula-ai/alego-timeout':
         specifier: workspace:^
         version: link:../../util/timeout
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/llm/llm-pi-ai:
     dependencies:
-      '@singula-ai/schemastery':
-        specifier: link:../../../vendor/schemastery
-        version: link:../../../vendor/schemastery
       '@earendil-works/pi-ai':
         specifier: ^0.82.1
         version: 0.82.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@singula-ai/schemastery':
+        specifier: link:../../../vendor/schemastery
+        version: link:../../../vendor/schemastery
     devDependencies:
       '@singula-ai/alego-attachment':
         specifier: workspace:^
@@ -5550,9 +5550,6 @@ importers:
       '@singula-ai/alego-authorization':
         specifier: workspace:^
         version: link:../../credentials/authorization
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-credentials':
         specifier: workspace:^
         version: link:../../credentials/credentials
@@ -5574,6 +5571,9 @@ importers:
       '@singula-ai/alego-timeout':
         specifier: workspace:^
         version: link:../../util/timeout
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/llm/llm-retry:
     dependencies:
@@ -5593,15 +5593,6 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:^
-        version: link:../../../vendor/include
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -5632,6 +5623,15 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:^
+        version: link:../../../vendor/include
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/llm/token-meter:
     dependencies:
@@ -5645,9 +5645,6 @@ importers:
       '@singula-ai/alego-compaction':
         specifier: workspace:^
         version: link:../../compaction/compaction
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -5660,21 +5657,24 @@ importers:
       '@singula-ai/alego-session-projection':
         specifier: workspace:^
         version: link:../../session/session-projection
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/lsp/lsp:
     devDependencies:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-llm':
         specifier: workspace:^
         version: link:../../llm/llm
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/lsp/lsp-stdio:
     dependencies:
@@ -5685,9 +5685,6 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-fs':
         specifier: workspace:^
         version: link:../../fs/fs
@@ -5712,6 +5709,9 @@ importers:
       '@singula-ai/alego-timeout':
         specifier: workspace:^
         version: link:../../util/timeout
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -5728,9 +5728,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-fs-local':
         specifier: workspace:^
         version: link:../../fs/fs-local
@@ -5764,28 +5761,34 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/mcp/mcp-client:
     dependencies:
-      '@singula-ai/schemastery':
-        specifier: link:../../../vendor/schemastery
-        version: link:../../../vendor/schemastery
       '@modelcontextprotocol/sdk':
         specifier: ^1.12.0
         version: 1.29.0(zod@4.4.3)
+      '@singula-ai/schemastery':
+        specifier: link:../../../vendor/schemastery
+        version: link:../../../vendor/schemastery
       zod:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@modelcontextprotocol/server-everything':
+        specifier: ^2026.7.4
+        version: 2026.7.4
+      '@modelcontextprotocol/server-filesystem':
+        specifier: ^2026.7.4
+        version: 2026.7.10(zod@4.4.3)
       '@singula-ai/alego-attachment':
         specifier: workspace:^
         version: link:../../attachment/attachment
       '@singula-ai/alego-attachment-local':
         specifier: workspace:^
         version: link:../../attachment/attachment-local
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -5801,12 +5804,9 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
-      '@modelcontextprotocol/server-everything':
-        specifier: ^2026.7.4
-        version: 2026.7.4
-      '@modelcontextprotocol/server-filesystem':
-        specifier: ^2026.7.4
-        version: 2026.7.10(zod@4.4.3)
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/plan/plan-mode:
     dependencies:
@@ -5826,9 +5826,6 @@ importers:
       '@singula-ai/alego-commands':
         specifier: workspace:^
         version: link:../../interaction/commands
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -5850,6 +5847,9 @@ importers:
       '@singula-ai/alego-user-questions':
         specifier: workspace:^
         version: link:../../interaction/user-questions
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/preset/agent-presets:
     dependencies:
@@ -5869,15 +5869,6 @@ importers:
       '@singula-ai/alego-atomic-write':
         specifier: workspace:^
         version: link:../../util/atomic-write
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:^
-        version: link:../../../vendor/include
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-home-paths':
         specifier: workspace:^
         version: link:../../util/home-paths
@@ -5905,6 +5896,15 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:^
+        version: link:../../../vendor/include
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/preset/persona:
     dependencies:
@@ -5912,9 +5912,6 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -5924,6 +5921,9 @@ importers:
       '@singula-ai/alego-system-prompt':
         specifier: workspace:^
         version: link:../../core/system-prompt
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/runtime-diagnostics/invariants:
     dependencies:
@@ -5937,9 +5937,6 @@ importers:
 
   packages/sandbox/sandbox:
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -5949,22 +5946,22 @@ importers:
       '@singula-ai/alego-session':
         specifier: workspace:^
         version: link:../../core/session
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/sandbox/sandbox-local:
     dependencies:
-      '@singula-ai/node-addon-landlock-run':
-        specifier: workspace:^
-        version: link:../../../native/landlock-run/packages/entry
       '@singula-ai/alego-sandbox-windows-acl':
         specifier: workspace:^
         version: link:../sandbox-windows-acl
+      '@singula-ai/node-addon-landlock-run':
+        specifier: workspace:^
+        version: link:../../../native/landlock-run/packages/entry
       '@singula-ai/schemastery':
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -5977,6 +5974,9 @@ importers:
       '@singula-ai/alego-session':
         specifier: workspace:^
         version: link:../../core/session
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/sandbox/sandbox-policy:
     dependencies:
@@ -5987,9 +5987,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6002,6 +5999,9 @@ importers:
       '@singula-ai/alego-system-prompt':
         specifier: workspace:^
         version: link:../../core/system-prompt
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/sandbox/sandbox-windows-acl:
     dependencies:
@@ -6009,9 +6009,6 @@ importers:
         specifier: ^3.1.0
         version: 3.1.1
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6021,6 +6018,9 @@ importers:
       '@singula-ai/alego-sandbox-local':
         specifier: workspace:^
         version: link:../sandbox-local
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/schedule/schedule:
     devDependencies:
@@ -6036,12 +6036,6 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6063,12 +6057,15 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
-
-  packages/sdk/client:
-    devDependencies:
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
+
+  packages/sdk/client:
+    devDependencies:
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6081,12 +6078,12 @@ importers:
       '@singula-ai/alego-session':
         specifier: workspace:^
         version: link:../../core/session
-
-  packages/sdk/protocol:
-    devDependencies:
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
+
+  packages/sdk/protocol:
+    devDependencies:
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6099,6 +6096,9 @@ importers:
       '@singula-ai/alego-subagent':
         specifier: workspace:^
         version: link:../../subagent/subagent
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/sdk/server:
     dependencies:
@@ -6112,12 +6112,6 @@ importers:
       '@singula-ai/alego-agent-spine-demo':
         specifier: workspace:^
         version: link:../../examples/agent-spine-demo
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6142,6 +6136,12 @@ importers:
       '@singula-ai/alego-subagent':
         specifier: workspace:^
         version: link:../../subagent/subagent
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/session-query/session-log-export:
     devDependencies:
@@ -6169,18 +6169,18 @@ importers:
       '@singula-ai/alego-commands':
         specifier: workspace:^
         version: link:../../interaction/commands
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-session':
         specifier: workspace:^
         version: link:../../core/session
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -6193,9 +6193,6 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6211,6 +6208,9 @@ importers:
       '@singula-ai/alego-session-title':
         specifier: workspace:^
         version: link:../../session/session-title
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/session-query/session-query-sqlite:
     dependencies:
@@ -6218,12 +6218,6 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6239,6 +6233,12 @@ importers:
       '@singula-ai/alego-session-query':
         specifier: workspace:^
         version: link:../session-query
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/session-query/tool-session-query:
     dependencies:
@@ -6249,9 +6249,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6288,6 +6285,9 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/session/session-checkpoint-policy:
     devDependencies:
@@ -6300,12 +6300,6 @@ importers:
       '@singula-ai/alego-agent-loop-testkit':
         specifier: workspace:^
         version: link:../../test-support/agent-loop-testkit
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6327,15 +6321,18 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/session/session-persistence:
     devDependencies:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6348,6 +6345,9 @@ importers:
       '@singula-ai/alego-timeout':
         specifier: workspace:^
         version: link:../../util/timeout
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/session/session-persistence-jsonl:
     dependencies:
@@ -6358,9 +6358,6 @@ importers:
         specifier: ^3.1.0
         version: 3.1.1
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6370,6 +6367,9 @@ importers:
       '@singula-ai/alego-session-persistence':
         specifier: workspace:^
         version: link:../session-persistence
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/session/session-persistence-sqlite:
     dependencies:
@@ -6377,15 +6377,6 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:^
-        version: link:../../../vendor/include
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6398,6 +6389,15 @@ importers:
       '@singula-ai/alego-session-persistence':
         specifier: workspace:^
         version: link:../session-persistence
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:^
+        version: link:../../../vendor/include
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -6408,15 +6408,15 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-session':
         specifier: workspace:^
         version: link:../../core/session
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/session/session-projection-cache:
     dependencies:
@@ -6427,9 +6427,6 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6448,6 +6445,9 @@ importers:
       '@singula-ai/alego-storage-domain':
         specifier: workspace:^
         version: link:../../storage/storage-domain
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/session/session-stats:
     dependencies:
@@ -6455,15 +6455,6 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:^
-        version: link:../../../vendor/include
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6476,27 +6467,33 @@ importers:
       '@singula-ai/alego-session-projection':
         specifier: workspace:^
         version: link:../session-projection
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:^
+        version: link:../../../vendor/include
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/session/session-telemetry:
     devDependencies:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-session':
         specifier: workspace:^
         version: link:../../core/session
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/session/session-telemetry-otel:
     dependencies:
-      '@singula-ai/schemastery':
-        specifier: link:../../../vendor/schemastery
-        version: link:../../../vendor/schemastery
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -6515,6 +6512,9 @@ importers:
       '@opentelemetry/sdk-logs':
         specifier: ^0.220.0
         version: 0.220.0(@opentelemetry/api@1.9.1)
+      '@singula-ai/schemastery':
+        specifier: link:../../../vendor/schemastery
+        version: link:../../../vendor/schemastery
     devDependencies:
       '@singula-ai/alego-anonymous-user-id':
         specifier: workspace:^
@@ -6522,12 +6522,6 @@ importers:
       '@singula-ai/alego-command-feedback':
         specifier: workspace:^
         version: link:../../feedback/command-feedback
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6540,6 +6534,12 @@ importers:
       '@singula-ai/alego-session-telemetry':
         specifier: workspace:^
         version: link:../session-telemetry
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/session/session-title:
     dependencies:
@@ -6553,9 +6553,6 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6574,6 +6571,9 @@ importers:
       '@singula-ai/alego-session-projection':
         specifier: workspace:^
         version: link:../session-projection
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/session/session-title-all-prompts-llm:
     dependencies:
@@ -6581,9 +6581,6 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6599,6 +6596,9 @@ importers:
       '@singula-ai/alego-session-title-llm':
         specifier: workspace:^
         version: link:../session-title-llm
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/session/session-title-first-prompt-llm:
     dependencies:
@@ -6606,15 +6606,6 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:^
-        version: link:../../../vendor/include
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6633,6 +6624,15 @@ importers:
       '@singula-ai/alego-session-title-llm':
         specifier: workspace:^
         version: link:../session-title-llm
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:^
+        version: link:../../../vendor/include
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/session/session-title-llm:
     dependencies:
@@ -6640,9 +6640,6 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6658,6 +6655,9 @@ importers:
       '@singula-ai/alego-timeout':
         specifier: workspace:^
         version: link:../../util/timeout
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/settings/settings:
     dependencies:
@@ -6668,12 +6668,12 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/settings/settings-file:
     dependencies:
@@ -6690,9 +6690,6 @@ importers:
       '@singula-ai/alego-atomic-write':
         specifier: workspace:^
         version: link:../../util/atomic-write
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-home-paths':
         specifier: workspace:^
         version: link:../../util/home-paths
@@ -6702,6 +6699,9 @@ importers:
       '@singula-ai/alego-settings':
         specifier: workspace:^
         version: link:../settings
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/shell/bash-local:
     dependencies:
@@ -6709,9 +6709,6 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6730,21 +6727,18 @@ importers:
       '@singula-ai/alego-timeout':
         specifier: workspace:^
         version: link:../../util/timeout
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/shell/bash-sandbox:
     devDependencies:
       '@singula-ai/alego-bash-local':
         specifier: workspace:^
         version: link:../bash-local
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
-      '@singula-ai/node-addon-landlock-run':
-        specifier: workspace:^
-        version: link:../../../native/landlock-run/packages/entry
       '@singula-ai/alego-sandbox':
         specifier: workspace:^
         version: link:../../sandbox/sandbox
@@ -6760,6 +6754,12 @@ importers:
       '@singula-ai/alego-subprocess-local':
         specifier: workspace:^
         version: link:../../subprocess/subprocess-local
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/node-addon-landlock-run':
+        specifier: workspace:^
+        version: link:../../../native/landlock-run/packages/entry
 
   packages/shell/pwsh-local:
     dependencies:
@@ -6767,9 +6767,6 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6788,12 +6785,12 @@ importers:
       '@singula-ai/alego-timeout':
         specifier: workspace:^
         version: link:../../util/timeout
-
-  packages/shell/pwsh-sandbox:
-    devDependencies:
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
+
+  packages/shell/pwsh-sandbox:
+    devDependencies:
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6815,12 +6812,12 @@ importers:
       '@singula-ai/alego-subprocess-local':
         specifier: workspace:^
         version: link:../../subprocess/subprocess-local
-
-  packages/shell/shell:
-    devDependencies:
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
+
+  packages/shell/shell:
+    devDependencies:
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6833,6 +6830,9 @@ importers:
       '@singula-ai/alego-subprocess':
         specifier: workspace:^
         version: link:../../subprocess/subprocess
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/shell/shell-env:
     dependencies:
@@ -6843,9 +6843,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-home-paths':
         specifier: workspace:^
         version: link:../../util/home-paths
@@ -6864,6 +6861,9 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/shell/tool-bash:
     dependencies:
@@ -6883,9 +6883,6 @@ importers:
       '@singula-ai/alego-bash-local':
         specifier: workspace:^
         version: link:../bash-local
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6931,6 +6928,9 @@ importers:
       '@singula-ai/alego-user-approval':
         specifier: workspace:^
         version: link:../../interaction/user-approval
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/shell/tool-bash-persistent:
     dependencies:
@@ -6941,15 +6941,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:^
-        version: link:../../../vendor/include
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -6983,6 +6974,15 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:^
+        version: link:../../../vendor/include
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/shell/tool-pwsh:
     dependencies:
@@ -6993,9 +6993,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -7041,6 +7038,9 @@ importers:
       '@singula-ai/alego-user-approval':
         specifier: workspace:^
         version: link:../../interaction/user-approval
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/shell/tool-pwsh-persistent:
     dependencies:
@@ -7051,15 +7051,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:^
-        version: link:../../../vendor/include
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -7096,6 +7087,15 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:^
+        version: link:../../../vendor/include
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/skill/skill:
     dependencies:
@@ -7103,9 +7103,6 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -7115,18 +7112,21 @@ importers:
       '@singula-ai/alego-scope':
         specifier: workspace:^
         version: link:../../core/scope
-
-  packages/skill/skill-badge:
-    devDependencies:
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
+
+  packages/skill/skill-badge:
+    devDependencies:
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-skill':
         specifier: workspace:^
         version: link:../skill
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/skill/skill-filesystem:
     dependencies:
@@ -7140,9 +7140,6 @@ importers:
         specifier: ^2.4.2
         version: 2.9.0
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-fs':
         specifier: workspace:^
         version: link:../../fs/fs
@@ -7155,6 +7152,9 @@ importers:
       '@singula-ai/alego-skill':
         specifier: workspace:^
         version: link:../skill
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/skill/tool-skill:
     dependencies:
@@ -7165,9 +7165,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -7189,15 +7186,15 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/spill/spill:
     devDependencies:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -7207,6 +7204,9 @@ importers:
       '@singula-ai/alego-session':
         specifier: workspace:^
         version: link:../../core/session
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/spill/spill-local:
     dependencies:
@@ -7217,9 +7217,6 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -7232,6 +7229,9 @@ importers:
       '@singula-ai/alego-spill':
         specifier: workspace:^
         version: link:../spill
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/spill/spill-policy:
     dependencies:
@@ -7245,9 +7245,6 @@ importers:
       '@singula-ai/alego-code-runtime-worker-thread':
         specifier: workspace:^
         version: link:../../code-runtime/code-runtime-worker-thread
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -7266,15 +7263,18 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
-
-  packages/storage/storage:
-    devDependencies:
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
+
+  packages/storage/storage:
+    devDependencies:
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/storage/storage-domain:
     dependencies:
@@ -7285,15 +7285,15 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-storage':
         specifier: workspace:^
         version: link:../storage
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/storage/storage-json:
     dependencies:
@@ -7301,15 +7301,15 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-storage':
         specifier: workspace:^
         version: link:../storage
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/storage/storage-sqlite:
     dependencies:
@@ -7317,15 +7317,15 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-storage':
         specifier: workspace:^
         version: link:../storage
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/subagent/subagent:
     dependencies:
@@ -7342,9 +7342,6 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -7387,6 +7384,9 @@ importers:
       '@singula-ai/alego-user-approval':
         specifier: workspace:^
         version: link:../../interaction/user-approval
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/subagent/subagent-acp:
     dependencies:
@@ -7400,12 +7400,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -7430,6 +7424,12 @@ importers:
       '@singula-ai/alego-timeout':
         specifier: workspace:^
         version: link:../../util/timeout
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/subagent/subagent-alego-sdk:
     dependencies:
@@ -7440,12 +7440,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -7470,12 +7464,15 @@ importers:
       '@singula-ai/alego-subprocess':
         specifier: workspace:^
         version: link:../../subprocess/subprocess
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/subagent/subagent-claude-code:
     dependencies:
-      '@singula-ai/schemastery':
-        specifier: link:../../../vendor/schemastery
-        version: link:../../../vendor/schemastery
       '@anthropic-ai/claude-agent-sdk':
         specifier: 0.3.220
         version: 0.3.220(@anthropic-ai/sdk@0.93.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
@@ -7485,6 +7482,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
+      '@singula-ai/schemastery':
+        specifier: link:../../../vendor/schemastery
+        version: link:../../../vendor/schemastery
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -7492,9 +7492,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -7519,52 +7516,55 @@ importers:
       '@singula-ai/alego-timeout':
         specifier: workspace:^
         version: link:../../util/timeout
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/subagent/subagent-codex:
     dependencies:
-      '@singula-ai/schemastery':
-        specifier: link:../../../vendor/schemastery
-        version: link:../../../vendor/schemastery
-      '@singula-ai/alego-sdk-protocol':
-        specifier: workspace:^
-        version: link:../../sdk/protocol
       '@openai/codex':
         specifier: 0.147.0
         version: 0.147.0
+      '@singula-ai/alego-sdk-protocol':
+        specifier: workspace:^
+        version: link:../../sdk/protocol
+      '@singula-ai/schemastery':
+        specifier: link:../../../vendor/schemastery
+        version: link:../../../vendor/schemastery
     devDependencies:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
+      '@singula-ai/alego-invariants':
+        specifier: workspace:^
+        version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/alego-llm':
+        specifier: workspace:^
+        version: link:../../llm/llm
+      '@singula-ai/alego-loader-smoke':
+        specifier: workspace:^
+        version: link:../../test-support/loader-smoke
+      '@singula-ai/alego-session':
+        specifier: workspace:^
+        version: link:../../core/session
+      '@singula-ai/alego-subagent':
+        specifier: workspace:^
+        version: link:../subagent
+      '@singula-ai/alego-subprocess':
+        specifier: workspace:^
+        version: link:../../subprocess/subprocess
+      '@singula-ai/alego-subprocess-local':
+        specifier: workspace:^
+        version: link:../../subprocess/subprocess-local
+      '@singula-ai/alego-timeout':
+        specifier: workspace:^
+        version: link:../../util/timeout
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
       '@singula-ai/cordis-plugin-loader':
         specifier: workspace:^
         version: link:../../../vendor/loader
-      '@singula-ai/alego-invariants':
-        specifier: workspace:^
-        version: link:../../runtime-diagnostics/invariants
-      '@singula-ai/alego-llm':
-        specifier: workspace:^
-        version: link:../../llm/llm
-      '@singula-ai/alego-loader-smoke':
-        specifier: workspace:^
-        version: link:../../test-support/loader-smoke
-      '@singula-ai/alego-session':
-        specifier: workspace:^
-        version: link:../../core/session
-      '@singula-ai/alego-subagent':
-        specifier: workspace:^
-        version: link:../subagent
-      '@singula-ai/alego-subprocess':
-        specifier: workspace:^
-        version: link:../../subprocess/subprocess
-      '@singula-ai/alego-subprocess-local':
-        specifier: workspace:^
-        version: link:../../subprocess/subprocess-local
-      '@singula-ai/alego-timeout':
-        specifier: workspace:^
-        version: link:../../util/timeout
 
   packages/subagent/subagent-fork-in-process:
     dependencies:
@@ -7581,12 +7581,6 @@ importers:
       '@singula-ai/alego-agent-loop-testkit':
         specifier: workspace:^
         version: link:../../test-support/agent-loop-testkit
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -7605,6 +7599,12 @@ importers:
       '@singula-ai/alego-subagent-spawn-in-process':
         specifier: workspace:^
         version: link:../subagent-spawn-in-process
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/subagent/subagent-in-process-driver:
     devDependencies:
@@ -7620,15 +7620,6 @@ importers:
       '@singula-ai/alego-agent-presets':
         specifier: workspace:^
         version: link:../../preset/agent-presets
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:^
-        version: link:../../../vendor/include
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-fs-sandbox':
         specifier: workspace:^
         version: link:../../fs/fs-sandbox
@@ -7659,6 +7650,15 @@ importers:
       '@singula-ai/alego-user-approval':
         specifier: workspace:^
         version: link:../../interaction/user-approval
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:^
+        version: link:../../../vendor/include
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/subagent/subagent-spawn-in-process:
     dependencies:
@@ -7678,12 +7678,6 @@ importers:
       '@singula-ai/alego-bash-local':
         specifier: workspace:^
         version: link:../../shell/bash-local
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -7711,6 +7705,12 @@ importers:
       '@singula-ai/alego-tool-subagent':
         specifier: workspace:^
         version: link:../tool-subagent
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/subagent/tool-subagent:
     dependencies:
@@ -7721,12 +7721,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -7763,6 +7757,12 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/subagent/tool-subagent-control:
     devDependencies:
@@ -7775,9 +7775,6 @@ importers:
       '@singula-ai/alego-agent-loop-testkit':
         specifier: workspace:^
         version: link:../../test-support/agent-loop-testkit
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -7805,6 +7802,9 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/subagent/tool-subagent-report:
     dependencies:
@@ -7821,9 +7821,6 @@ importers:
       '@singula-ai/alego-agent-loop-testkit':
         specifier: workspace:^
         version: link:../../test-support/agent-loop-testkit
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -7854,15 +7851,18 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
-
-  packages/subprocess/subprocess:
-    devDependencies:
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../../../vendor/cordis
+
+  packages/subprocess/subprocess:
+    devDependencies:
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/subprocess/subprocess-local:
     dependencies:
@@ -7873,9 +7873,6 @@ importers:
         specifier: 1.2.0-beta.15
         version: 1.2.0-beta.15(patch_hash=a5ed6ecd0db450ce363a37114d4cef63f0c05366bf7df152b3b0f18dc2297207)
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -7888,6 +7885,9 @@ importers:
       '@singula-ai/alego-timeout':
         specifier: workspace:^
         version: link:../../util/timeout
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/terminal/terminal:
     devDependencies:
@@ -7897,15 +7897,15 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-session':
         specifier: workspace:^
         version: link:../../core/session
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/terminal/terminal-bash:
     dependencies:
@@ -7919,9 +7919,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -7943,6 +7940,9 @@ importers:
       '@singula-ai/alego-terminal':
         specifier: workspace:^
         version: link:../terminal
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/terminal/tool-terminal:
     dependencies:
@@ -7953,15 +7953,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:^
-        version: link:../../../vendor/include
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -8004,6 +7995,15 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:^
+        version: link:../../../vendor/include
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/test-support/acp-snapshot:
     dependencies:
@@ -8017,15 +8017,15 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-session':
         specifier: workspace:^
         version: link:../../core/session
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/test-support/agent-loop-testkit:
     devDependencies:
@@ -8035,9 +8035,6 @@ importers:
       '@singula-ai/alego-agent-loop':
         specifier: workspace:^
         version: link:../../core/agent-loop
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -8053,6 +8050,9 @@ importers:
       '@singula-ai/alego-tools':
         specifier: workspace:^
         version: link:../../core/tools
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/test-support/client-runtime:
     dependencies:
@@ -8075,15 +8075,15 @@ importers:
       '@singula-ai/alego-client-ui-slots':
         specifier: workspace:^
         version: link:../../client/ui-slots
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-host-apiproxy':
         specifier: workspace:^
         version: link:../../host/apiproxy
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/react':
         specifier: ~18.3.1
         version: 18.3.31
@@ -8099,21 +8099,18 @@ importers:
 
   packages/test-support/llm-mock-server:
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/test-support/llm-replay:
     devDependencies:
       '@singula-ai/alego-compaction':
         specifier: workspace:^
         version: link:../../compaction/compaction
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -8123,6 +8120,9 @@ importers:
       '@singula-ai/alego-session':
         specifier: workspace:^
         version: link:../../core/session
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/test-support/loader-smoke:
     dependencies:
@@ -8136,9 +8136,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -8148,6 +8145,9 @@ importers:
       '@singula-ai/alego-session':
         specifier: workspace:^
         version: link:../../core/session
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/todo/tool-todo:
     dependencies:
@@ -8167,15 +8167,6 @@ importers:
       '@singula-ai/alego-agent-loop-testkit':
         specifier: workspace:^
         version: link:../../test-support/agent-loop-testkit
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:^
-        version: link:../../../vendor/include
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-host-apiproxy':
         specifier: workspace:^
         version: link:../../host/apiproxy
@@ -8200,6 +8191,15 @@ importers:
       '@singula-ai/alego-user-questions':
         specifier: workspace:^
         version: link:../../interaction/user-questions
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:^
+        version: link:../../../vendor/include
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/typert/generator:
     dependencies:
@@ -8210,9 +8210,6 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -8222,6 +8219,9 @@ importers:
       '@singula-ai/alego-typert-registry':
         specifier: workspace:^
         version: link:../registry
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -8232,30 +8232,30 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-typert-registry':
         specifier: workspace:^
         version: link:../registry
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
       zod:
         specifier: ^4.4.3
         version: 4.4.3
 
   packages/typert/protocol:
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/typert/registry:
     dependencies:
@@ -8266,84 +8266,84 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/util/atomic-write:
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/util/brand:
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/util/home-paths:
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/util/launch-environment:
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/util/native-command:
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/util/output-retention:
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/util/timeout:
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/web/tool-web:
     dependencies:
-      '@singula-ai/schemastery':
-        specifier: link:../../../vendor/schemastery
-        version: link:../../../vendor/schemastery
       '@joplin/turndown-plugin-gfm':
         specifier: ^1.0.67
         version: 1.0.67
+      '@singula-ai/schemastery':
+        specifier: link:../../../vendor/schemastery
+        version: link:../../../vendor/schemastery
       turndown:
         specifier: ^7.2.4
         version: 7.2.4
@@ -8351,9 +8351,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -8387,6 +8384,9 @@ importers:
       '@singula-ai/alego-web-search-exa':
         specifier: workspace:^
         version: link:../web-search-exa
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       '@types/turndown':
         specifier: ^5.0.6
         version: 5.0.6
@@ -8397,15 +8397,15 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
       '@singula-ai/alego-llm':
         specifier: workspace:^
         version: link:../../llm/llm
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/web/web-fetch-http:
     dependencies:
@@ -8413,9 +8413,6 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -8425,6 +8422,9 @@ importers:
       '@singula-ai/alego-web':
         specifier: workspace:^
         version: link:../web
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/web/web-search-deepseek:
     dependencies:
@@ -8435,9 +8435,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-credentials':
         specifier: workspace:^
         version: link:../../credentials/credentials
@@ -8459,6 +8456,9 @@ importers:
       '@singula-ai/alego-web':
         specifier: workspace:^
         version: link:../web
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/web/web-search-exa:
     dependencies:
@@ -8466,9 +8466,6 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -8478,6 +8475,9 @@ importers:
       '@singula-ai/alego-web':
         specifier: workspace:^
         version: link:../web
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/web/web-search-perplexity:
     dependencies:
@@ -8485,9 +8485,6 @@ importers:
         specifier: link:../../../vendor/schemastery
         version: link:../../../vendor/schemastery
     devDependencies:
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -8497,6 +8494,9 @@ importers:
       '@singula-ai/alego-web':
         specifier: workspace:^
         version: link:../web
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/workflow/tool-ralph:
     dependencies:
@@ -8513,12 +8513,6 @@ importers:
       '@singula-ai/alego-agent-loop-testkit':
         specifier: workspace:^
         version: link:../../test-support/agent-loop-testkit
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../../vendor/loader
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -8549,6 +8543,12 @@ importers:
       '@singula-ai/alego-workflow-worker-thread':
         specifier: workspace:^
         version: link:../workflow-worker-thread
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../../vendor/loader
 
   packages/workflow/tool-workflow:
     dependencies:
@@ -8559,9 +8559,6 @@ importers:
       '@singula-ai/alego-agent':
         specifier: workspace:^
         version: link:../../core/agent
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -8586,6 +8583,9 @@ importers:
       '@singula-ai/alego-workflow-worker-thread':
         specifier: workspace:^
         version: link:../workflow-worker-thread
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/workflow/workflow:
     devDependencies:
@@ -8595,9 +8595,6 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -8607,6 +8604,9 @@ importers:
       '@singula-ai/alego-session':
         specifier: workspace:^
         version: link:../../core/session
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   packages/workflow/workflow-worker-thread:
     dependencies:
@@ -8626,9 +8626,6 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -8653,6 +8650,9 @@ importers:
       '@singula-ai/alego-workflow':
         specifier: workspace:^
         version: link:../workflow
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
       tsx:
         specifier: ^4.19.2
         version: 4.22.4
@@ -8666,9 +8666,6 @@ importers:
       '@singula-ai/alego-brand':
         specifier: workspace:^
         version: link:../../util/brand
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../../vendor/cordis
       '@singula-ai/alego-invariants':
         specifier: workspace:^
         version: link:../../runtime-diagnostics/invariants
@@ -8684,6 +8681,9 @@ importers:
       '@singula-ai/alego-storage-domain':
         specifier: workspace:^
         version: link:../../storage/storage-domain
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../../vendor/cordis
 
   python/sdk-runtime:
     dependencies:
@@ -8750,27 +8750,9 @@ importers:
       '@singula-ai/alego-compaction-tool-result-pruner':
         specifier: workspace:^
         version: link:../../packages/compaction/compaction-tool-result-pruner
-      '@singula-ai/cordis':
-        specifier: workspace:^
-        version: link:../../vendor/cordis
       '@singula-ai/alego-cordis-host-runner':
         specifier: workspace:^
         version: link:../../packages/extensions/cordis-host-runner
-      '@singula-ai/cordis-plugin-group':
-        specifier: workspace:^
-        version: link:../../vendor/group
-      '@singula-ai/cordis-plugin-include':
-        specifier: workspace:^
-        version: link:../../vendor/include
-      '@singula-ai/cordis-plugin-loader':
-        specifier: workspace:^
-        version: link:../../vendor/loader
-      '@singula-ai/cordis-plugin-timer':
-        specifier: workspace:^
-        version: link:../../vendor/timer
-      '@singula-ai/cosmokit':
-        specifier: link:../../vendor/cosmokit
-        version: link:../../vendor/cosmokit
       '@singula-ai/alego-credentials':
         specifier: workspace:^
         version: link:../../packages/credentials/credentials
@@ -8858,9 +8840,6 @@ importers:
       '@singula-ai/alego-sandbox-policy':
         specifier: workspace:^
         version: link:../../packages/sandbox/sandbox-policy
-      '@singula-ai/schemastery':
-        specifier: link:../../vendor/schemastery
-        version: link:../../vendor/schemastery
       '@singula-ai/alego-scope':
         specifier: workspace:^
         version: link:../../packages/core/scope
@@ -9041,6 +9020,27 @@ importers:
       '@singula-ai/alego-workflow-worker-thread':
         specifier: workspace:^
         version: link:../../packages/workflow/workflow-worker-thread
+      '@singula-ai/cordis':
+        specifier: workspace:^
+        version: link:../../vendor/cordis
+      '@singula-ai/cordis-plugin-group':
+        specifier: workspace:^
+        version: link:../../vendor/group
+      '@singula-ai/cordis-plugin-include':
+        specifier: workspace:^
+        version: link:../../vendor/include
+      '@singula-ai/cordis-plugin-loader':
+        specifier: workspace:^
+        version: link:../../vendor/loader
+      '@singula-ai/cordis-plugin-timer':
+        specifier: workspace:^
+        version: link:../../vendor/timer
+      '@singula-ai/cosmokit':
+        specifier: link:../../vendor/cosmokit
+        version: link:../../vendor/cosmokit
+      '@singula-ai/schemastery':
+        specifier: link:../../vendor/schemastery
+        version: link:../../vendor/schemastery
 
   vendor/cordis:
     dependencies:
@@ -9070,6 +9070,9 @@ importers:
 
   vendor/hmr:
     dependencies:
+      '@babel/code-frame':
+        specifier: ^7.29.0
+        version: 7.29.7
       '@singula-ai/cordis':
         specifier: workspace:^
         version: link:../cordis
@@ -9082,9 +9085,6 @@ importers:
       '@singula-ai/schemastery':
         specifier: link:../schemastery
         version: link:../schemastery
-      '@babel/code-frame':
-        specifier: ^7.29.0
-        version: 7.29.7
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3


### PR DESCRIPTION
Issue: none yet in this repository.

<details>
<summary>Changes and verification</summary>

Promotes the alego release family from the `0.1.1-rc.2` prerelease to the stable `0.1.1`, so the published packages take the `latest` dist-tag and `npx @singula-ai/alego` resolves as the README documents. A prerelease version publishes under `next` and never takes `latest`, which would leave the documented entry point unresolvable.

Produced by `pnpm run release:alego 0.1.1`: one version across the 227 publishable members, the two private experimental packages, and the workspace root, with the lockfile following. 231 files, no hand edits.

**Verification**

- `pnpm run release:verify --family alego` — 227 members, one shared version `0.1.1`, publish order resolved over 227 entries. The single unordered peer (`alego-api-remotes -> alego-api-gateway`) is the documented cycle-breaker; npm treats an unmet peer as a warning.
- Version consistency checked independently: 229 manifests plus the workspace root all read `0.1.1`.
- Pre-commit (whitespace, vendor guard) and pre-push (incremental typecheck) passed.

**Expected check state.** Four CI jobs (`node 24 / static`, `coverage`, `snapshots and artifacts`, `windows node 24 / native complete`) target the larger-runner labels `alego-ubuntu-24-04-16core` and `alego-windows-2025-16core`, which a GitHub Free organization cannot provide, so they queue indefinitely. That is inherited configuration and is being fixed separately. The meaningful gate for this change is `Release (alego)`, which packs all 227 members at the new version and drives the packed-install probe on a standard runner.

</details>
