### PR TITLE
release(alego): 0.1.2 with a rate-limit-surviving publish step

### DIFF
--- a/.agents/notes/implemented/process/2026-08-24-npm-publish-rate-limit-recovery.i18n.yaml
+++ b/.agents/notes/implemented/process/2026-08-24-npm-publish-rate-limit-recovery.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/process/2026-08-24-npm-publish-rate-limit-recovery.md
+2026-08-24-npm-publish-rate-limit-recovery.md: 4f329635d9a9e7983e9d1089b403324d6a7f95a0
+2026-08-24-npm-publish-rate-limit-recovery.zh.md: 87a4b490f6be9173f0ea86b627813223677037ba

--- a/.agents/notes/implemented/process/2026-08-24-npm-publish-rate-limit-recovery.md
+++ b/.agents/notes/implemented/process/2026-08-24-npm-publish-rate-limit-recovery.md
@@ -1,0 +1,33 @@
+# Agent Note: Rate-limited npm publication recovers by re-running, never re-packing
+
+Status: implemented
+
+English | [中文](2026-08-24-npm-publish-rate-limit-recovery.zh.md)
+
+## Problem
+
+The first alego publication hit the registry's meter on new-package creation: after 25 new packages in one day across the vendor, native, and alego sequences, every further publish answered `E429 rate limited exceeded` for hours, from CI and from a residential connection alike, so the limit follows the account rather than request rate, client version, or network. The publish step's retry ladder waited 2–8 seconds while npm's own in-client retries had already waited about a minute per invocation, so one metering window failed the run after 13 of 227 members. Recovery then met a second wall: a fresh dispatch re-packs, and this repository's build is not byte-reproducible — two packs of one commit differed by 18 bytes — so the integrity guard correctly refused to continue over the members the first run had published.
+
+## Decision
+
+`publishTarball` keeps two independent retry budgets: `E429` waits on its own ladder of five doubling backoffs from one minute (~31 minutes in total, long enough to ride out metering while a hard quota still fails within the job), and every other transient code keeps the seconds-scale ladder that answers `E409` packument settling. The judgement is the exported pure `publishRetryDirective` in [scripts/release/publish.ts](../../../../scripts/release/publish.ts), covered by [scripts/release/publish.spec.ts](../../../../scripts/release/publish.spec.ts).
+
+Recovery from a partial publication re-runs the failed publish job of the original workflow run, because that reuses the run's packed artifact: already-published members skip on identical integrity, which the incident proved across four such re-runs. A fresh dispatch is never a resume — it re-packs, and until reproducibility is fixed the first dispatch's artifact is the release's only publishable bytes.
+
+Registry verification after publishing reads `/{package}/{version}`: the packument endpoint serves long-lived cached 404s for names polled before they existed and reported nine live packages as absent.
+
+## Alternatives considered
+
+**Longer spacing between publishes (10–30 seconds).** Rejected: attempts 45–85 minutes apart still answered `E429` on their first PUT, so the meter is a count quota over a long window, not a request rate; spacing spends wall-clock without buying budget.
+
+**Publishing from a different network.** Tried: a residential connection with the same token and the same artifact bytes answered the identical `E429`, ruling out keying on CI egress addresses.
+
+**One in-job wait long enough for any window.** Rejected: a window of hours would idle a runner against the six-hour job ceiling, while re-running the publish job later resumes identically for free.
+
+**Unpublishing the partial set to restart clean.** Unavailable: the registry refuses DELETE from a bypass-2FA token, and enabling account 2FA for an interactive unpublish failed in practice.
+
+## Consequences
+
+- A hard quota still fails a run after ~31 minutes on one member; the recovery is re-running that run's publish job once the window opens, and otherwise a registry support request (filed for the first release on 2026-08-24).
+- Byte reproducibility remains unmeasured and unfixed; `packages/util/brand` is the smallest reproduction of the drift. Fix it before any release whose re-pack must equal a prior pack.
+- 13 members remain published at 0.1.1 with no entry package, because that family's completion was abandoned with its history; the first complete release is 0.1.2. They cannot be unpublished: the publishing token bypasses 2FA and the registry refuses DELETE from such tokens.

--- a/.agents/notes/implemented/process/2026-08-24-npm-publish-rate-limit-recovery.zh.md
+++ b/.agents/notes/implemented/process/2026-08-24-npm-publish-rate-limit-recovery.zh.md
@@ -1,0 +1,33 @@
+# Agent Note：npm 发布触发限流后靠重跑恢复，绝不重新打包
+
+Status: implemented
+
+[English](2026-08-24-npm-publish-rate-limit-recovery.md) | 中文
+
+## Problem
+
+alego 的首次发布撞上了 registry 对新建包的计量：vendor、native、alego 三个序列一天内新建 25 个包之后，后续每次发布都持续数小时返回 `E429 rate limited exceeded`，CI 与家用网络无一例外，因此该限制跟随账号，而非请求速率、客户端版本或网络。发布步骤的重试梯子只等 2–8 秒，而 npm 客户端自身的内部重试每次调用已等约一分钟，于是一个计量窗口就让整次运行在 227 个成员发布到第 13 个时失败。恢复又撞上第二堵墙：重新 dispatch 会重新打包，而本仓库的构建并非字节可复现——同一 commit 的两次打包相差 18 字节——完整性门禁因此正确地拒绝越过首次运行已发布的成员继续。
+
+## Decision
+
+`publishTarball` 维护两条彼此独立的重试预算：`E429` 走自己的梯子，从一分钟起五次翻倍退避（合计约 31 分钟，足以熬过计量窗口，硬配额则仍在 job 时限内失败）；其余瞬态码保留应对 `E409` packument 落盘的秒级梯子。该判定是 [scripts/release/publish.ts](../../../../scripts/release/publish.ts) 中导出的纯函数 `publishRetryDirective`，由 [scripts/release/publish.spec.ts](../../../../scripts/release/publish.spec.ts) 覆盖。
+
+部分发布的恢复方式是重跑原 workflow run 中失败的 publish job，因为重跑复用该 run 打好的 artifact：已发布成员按相同完整性跳过，事故中四次这样的重跑都证明了这一点。重新 dispatch 永远不是续传——它会重新打包；在可复现性修复之前，首次 dispatch 的 artifact 就是该次发布唯一可发布的字节。
+
+发布后的 registry 校验读取 `/{package}/{version}`：packument 端点会对发布前查询过的包名返回长期缓存的 404，曾把九个已上线的包报告为不存在。
+
+## Alternatives considered
+
+**拉长发布间隔（10–30 秒）。**拒绝：间隔 45–85 分钟的多次尝试仍在首个 PUT 上收到 `E429`，说明计量是长窗口的计数配额而非请求速率；加大间隔只消耗墙钟时间，买不来配额。
+
+**换网络发布。**试过：家用网络用同一 token、同一 artifact 字节收到完全相同的 `E429`，排除了按 CI 出口地址计费的可能。
+
+**在 job 内等足任意窗口。**拒绝：窗口若以小时计，会让 runner 在六小时 job 上限内空转；稍后重跑 publish job 能免费获得同样的续传。
+
+**下架已发布的部分成员重新开始。**不可用：registry 拒绝 bypass-2FA token 的 DELETE，而为交互式下架启用账号 2FA 在实践中未能完成。
+
+## Consequences
+
+- 硬配额仍会让一次运行在单个成员上耗约 31 分钟后失败；恢复手段是等窗口打开后重跑该 run 的 publish job，再不行就向 registry 提交支持工单（首次发布已于 2026-08-24 提交）。
+- 字节可复现性仍未测量、未修复；`packages/util/brand` 是该漂移的最小复现。任何要求重打包与先前打包相等的发布之前必须先修复。
+- 13 个成员滞留在 0.1.1 且没有入口包，因为该族的收尾随其历史一起被放弃；首个完整发布是 0.1.2。它们无法下架：发布用 token 绕过 2FA，而 registry 拒绝此类 token 的 DELETE。

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego",
   "description": "alego CLI: profile boot, plugin management, and the browser UI alias",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-web-frontend",
   "description": "Web application entry: vite build over the @singula-ai/alego-client-web shell library; dist/ served by apps/cli's alego web",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@singula-ai/alego-root",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/packages/acp/acp/package.json
+++ b/packages/acp/acp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-acp",
   "description": "Automation-only Agent Client Protocol server for driving Alego agents over JSON-RPC stdio",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/gateway/package.json
+++ b/packages/api/gateway/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-api-gateway",
   "description": "Typert Remote Host dispatcher and Client API endpoint",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/remotes/package.json
+++ b/packages/api/remotes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-api-remotes",
   "description": "Remote BFF assembly and Host Agent/Session lookup policy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/attachment/attachment-local/package.json
+++ b/packages/attachment/attachment-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-attachment-local",
   "description": "Private content-addressed ALEGO_HOME attachment storage",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/attachment/attachment/package.json
+++ b/packages/attachment/attachment/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-attachment",
   "description": "Durable immutable attachment storage seam for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/boot/app-boot/package.json
+++ b/packages/boot/app-boot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-app-boot",
   "description": "Shared boot glue for the app bins: .env loading, fail-loud Loader guards, snapshot-aware config resolution, and the Loader boot sequence",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/boot/cmdline/package.json
+++ b/packages/boot/cmdline/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-cmdline",
   "description": "Immutable command-line handoff from an alego launcher to any app plugin that injects cmdlineArgs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bundle/base/package.json
+++ b/packages/bundle/base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-base",
   "description": "The shared alego core as a profile bundle: every profile's first patch layer, inserting the base plugin rows over the empty profile root",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bundle/headless/package.json
+++ b/packages/bundle/headless/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-headless",
   "description": "The alego one-shot bundle: a direct core Agent/Session runner over alego-base with no Host, HTTP, or browser layer",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bundle/web-app/package.json
+++ b/packages/bundle/web-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-web-app",
   "description": "The alego browser-surface bundle: the web patch layer over alego-base plus the runtime glue plugin (frontend dist serving, web-surface prompt, bash runtime variables, URL line)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/connection/package.json
+++ b/packages/client/connection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-connection",
   "description": "Wire consumer layer: HTTP-up/WebSocket-down client, ConnectionController dual streams with reconnect, and fixture api",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/hmr/package.json
+++ b/packages/client/hmr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-hmr",
   "description": "Dev-only hot-reload driver for script-loaded client entries: SSE rebuilt frames → invalidate/prefetch → fiber swap through the vendored Loader entry",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/locale/package.json
+++ b/packages/client/locale/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-locale",
   "description": "Locale plugin: Host-backed zh/en preference, browser-derived fallback, locale snapshots, and typed namespace dictionaries",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/modules/package.json
+++ b/packages/client/modules/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-modules",
   "description": "Client module system, dual-face: node half composes the __ALEGO_BOOT__ entry graph (incremental alego.client scan, bundle route, index tap, webPlugins service); browser half is the lazy-CJS module table the vendored cordis Loader consumes as its internal seam",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/runtime/package.json
+++ b/packages/client/runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-runtime",
   "description": "Client core services: SlotRegistry, SessionRuntime (scope tree + object layer)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-agent-preset/package.json
+++ b/packages/client/ui-agent-preset/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-agent-preset",
   "description": "Agent-preset surfaces: the default for later sessions, this session's seat, and the composition editor",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-attachment/package.json
+++ b/packages/client/ui-attachment/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-attachment",
   "description": "Dynamic attachment presentation plugin for conversation input and message-image slots",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-brand-official/package.json
+++ b/packages/client/ui-brand-official/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-brand-official",
   "description": "Official Alego brand occupants for the Web client's sidebar and conversation Hero slots",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-commands/package.json
+++ b/packages/client/ui-commands/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-commands",
   "description": "Client command surface: global directory cache, '/' source, three command UI kinds, popupSelect registry",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-conversation/package.json
+++ b/packages/client/ui-conversation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-conversation",
   "description": "Conversation domain: skeleton, ordered chat flow, composer with the Host-backed busy-Enter preference, and details host",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-deliverables/package.json
+++ b/packages/client/ui-deliverables/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-deliverables",
   "description": "Produced-files turn tail and clickable final-response file references for Web",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-directory-picker-browse/package.json
+++ b/packages/client/ui-directory-picker-browse/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-directory-picker-browse",
   "description": "In-app directory browsing surface: the workspace directory-flow owner rendering the host's listing and creation primitives",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-directory-picker-native/package.json
+++ b/packages/client/ui-directory-picker-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-directory-picker-native",
   "description": "Native directory-picker surface: the renderless workspace directory-flow occupant driving the host's OS chooser",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-goal/package.json
+++ b/packages/client/ui-goal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-goal",
   "description": "Session goal surface: GoalBar docked above the composer, read from the goal session projection",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-input-trigger/package.json
+++ b/packages/client/ui-input-trigger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-input-trigger",
   "description": "Input trigger pipeline: '/' and '@' detection, candidate menu, pick routing to registered sources",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-jobs/package.json
+++ b/packages/client/ui-jobs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-jobs",
   "description": "Session-header background-job list: live registry state mirrored from session/jobs frames",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/packages/client/ui-layout/package.json
+++ b/packages/client/ui-layout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-layout",
   "description": "Shell plugin: three-column AppFrame with drag handles, ctx.layout viewing-state service (navigation + panels)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-message-feedback/package.json
+++ b/packages/client/ui-message-feedback/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-message-feedback",
   "description": "Per-message feedback controls contributed to the assistant-message action strip, backed by the messageFeedback Host Remote",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-model-selection/package.json
+++ b/packages/client/ui-model-selection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-model-selection",
   "description": "Model selection: the /model popupSelect over session.models / session.selectModel",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-permission-presets/package.json
+++ b/packages/client/ui-permission-presets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-permission-presets",
   "description": "Permission surfaces: a new-session default in General settings and a current-session /permission popup over the permissions projection",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-plan/package.json
+++ b/packages/client/ui-plan/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-plan",
   "description": "Plan-mode composer control: the conversation.input.plan seat over the plan projection and the /plan command channel",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-primitives/package.json
+++ b/packages/client/ui-primitives/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-primitives",
   "description": "Pure React atoms for the alego web UI: controls, icons, markdown, and JSON inspectors (zero cordis)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-reference/package.json
+++ b/packages/client/ui-reference/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-reference",
   "description": "Unified Web @file and @session reference source",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-renderer/package.json
+++ b/packages/client/ui-renderer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-renderer",
   "description": "Browser UI renderer: React slot bindings, ctx.uiRenderer, and the assembled application root",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-settings-general/package.json
+++ b/packages/client/ui-settings-general/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-settings-general",
   "description": "Settings ownerless-copy and product onboarding plugin: the General section, shell trigger/header chrome content, settings dictionaries, and the versioned welcome notice",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-settings-models/package.json
+++ b/packages/client/ui-settings-models/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-settings-models",
   "description": "Models settings and shared product-onboarding dialogs over existing settings and credential joins",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-settings-plugin-inventory/package.json
+++ b/packages/client/ui-settings-plugin-inventory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-settings-plugin-inventory",
   "description": "Read-only Cordis Loader inventory tab in Web Plugins settings",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-settings-plugins/package.json
+++ b/packages/client/ui-settings-plugins/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-settings-plugins",
   "description": "Plugins settings section with feature-owned tabs and configurable host-plane plugin cards",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-settings/package.json
+++ b/packages/client/ui-settings/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-settings",
   "description": "Settings domain base plugin: the settings-namespace scope service and the canonical settings slot-type contract",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-sidebar/package.json
+++ b/packages/client/ui-sidebar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-sidebar",
   "description": "Sidebar plugin: session multi-level tree, search, grouping, state dots",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-skill/package.json
+++ b/packages/client/ui-skill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-skill",
   "description": "Web skill references and the dedicated skill tool row",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-slots/package.json
+++ b/packages/client/ui-slots/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-slots",
   "description": "Slot registry pure core: SlotMap declaration merging, single register composition API, four-share props types, store-seat types, renderer install seam",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-subagent/package.json
+++ b/packages/client/ui-subagent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-subagent",
   "description": "Subagent conversation catalog, continuation routing UI, and '@' reference source",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-theme/package.json
+++ b/packages/client/ui-theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-theme",
   "description": "Theme plugin: Host bootstrap for the pre-plugin palette; DOM-free ThemeRuntime for light/dark/system state; --dsw-* token styles and Appearance settings row",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-tool/package.json
+++ b/packages/client/ui-tool/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-tool",
   "description": "Client Tool call-tree renderer and keyed per-tool presentation slot",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-trajectory/package.json
+++ b/packages/client/ui-trajectory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-trajectory",
   "description": "Trajectory event ledger with an interactive timing overview: pure-consumer plugin registering into the conversation ViewMap (no service)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-user-questions/package.json
+++ b/packages/client/ui-user-questions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-user-questions",
   "description": "Web ask_user_question feature: host tool mount plus composer-takeover question UI",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-workflow-run/package.json
+++ b/packages/client/ui-workflow-run/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-workflow-run",
   "description": "Durable workflow-run Conversation Node and nested member disclosure for alego web",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/ui-workspace/package.json
+++ b/packages/client/ui-workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-workspace",
   "description": "Workspace picker plugin: one WorkspacePicker registered into the sidebar and empty-state workspace slots",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/web/package.json
+++ b/packages/client/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-web",
   "description": "Web boot kernel: static module table, Cordis loader, framework-free boot page, and UI-renderer handoff",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/code-runtime/code-runtime-python/package.json
+++ b/packages/code-runtime/code-runtime-python/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-code-runtime-python",
   "description": "CPython subprocess implementation of the Alego code-execution seam",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/code-runtime/code-runtime-worker-thread/package.json
+++ b/packages/code-runtime/code-runtime-worker-thread/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-code-runtime-worker-thread",
   "description": "Worker-thread implementation of the Alego code-execution seam",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/code-runtime/code-runtime/package.json
+++ b/packages/code-runtime/code-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-code-runtime",
   "description": "Abstract code-execution seam (ctx.codeRuntime) for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/compaction/command-compact/package.json
+++ b/packages/compaction/command-compact/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-command-compact",
   "description": "Human-facing slash command for explicit session compaction",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/compaction/compaction-basic/package.json
+++ b/packages/compaction/compaction-basic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-compaction-basic",
   "description": "Token-meter-driven compaction policy and LLM summarization backend for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/compaction/compaction-tool-result-pruner/package.json
+++ b/packages/compaction/compaction-tool-result-pruner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-compaction-tool-result-pruner",
   "description": "Replay-safe model-free head/middle/tail pruning for tool-result surface nodes",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/compaction/compaction/package.json
+++ b/packages/compaction/compaction/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-compaction",
   "description": "Abstract compaction service seam (ctx.compaction) for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/context/agent-instructions/package.json
+++ b/packages/context/agent-instructions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-agent-instructions",
   "description": "Workspace context loader for AGENTS.md/CLAUDE.md instruction files",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/context/file-reference-local/package.json
+++ b/packages/context/file-reference-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-file-reference-local",
   "description": "Local-filesystem ctx.fileReferences provider with bounded fuzzy indexes",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/context/file-reference/package.json
+++ b/packages/context/file-reference/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-file-reference",
   "description": "File-reference discovery contract and shared @file grammar",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/context/session-reference/package.json
+++ b/packages/context/session-reference/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-reference",
   "description": "Cross-session snapshot references and durable untrusted model context (ctx.sessionReferenceResolver)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/context/time-context/package.json
+++ b/packages/context/time-context/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-time-context",
   "description": "Opt-in durable per-step context with the current time and elapsed time",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/context/tmux-context/package.json
+++ b/packages/context/tmux-context/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tmux-context",
   "description": "Opt-in durable per-step context with this agent's tmux pane and window location",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/agent-default-model/package.json
+++ b/packages/core/agent-default-model/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-agent-default-model",
   "description": "Default model selection shared by Agent entry points",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/agent-loop/package.json
+++ b/packages/core/agent-loop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-agent-loop",
   "description": "The concrete agent loop plugin for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/agent-tool-presentation/package.json
+++ b/packages/core/agent-tool-presentation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-agent-tool-presentation",
   "description": "Agent-plane presentation selector: composes one agent's tools as Code Mode, native, or both",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/agent/package.json
+++ b/packages/core/agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-agent",
   "description": "Agent interface, registry, initiator scope, and event vocabulary for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/scope/package.json
+++ b/packages/core/scope/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-scope",
   "description": "Scoped-context registration primitive (scope tags, scope-filtered event dispatch) for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/session/package.json
+++ b/packages/core/session/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session",
   "description": "Event-sourced session store for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/system-prompt/package.json
+++ b/packages/core/system-prompt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-system-prompt",
   "description": "System prompt assembly registry for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/tools/package.json
+++ b/packages/core/tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tools",
   "description": "Tool registry and execution pipeline for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/credentials/authorization/package.json
+++ b/packages/credentials/authorization/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-authorization",
   "description": "Authorization seam (ctx.authorization): plugin-owned flows that obtain a credential through a conversation with the human",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/credentials/credentials-local/package.json
+++ b/packages/credentials/credentials-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-credentials-local",
   "description": "File-backed credentials provider ($ALEGO_HOME/.env under the live process environment) for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/credentials/credentials/package.json
+++ b/packages/credentials/credentials/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-credentials",
   "description": "Abstract credential seam (ctx.credentials): settings carry references to secrets, providers own the values",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/e2b/e2b/package.json
+++ b/packages/e2b/e2b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-e2b",
   "description": "Shared E2B sandbox lifecycle for Alego provider adapters",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/e2b/fs-e2b/package.json
+++ b/packages/e2b/fs-e2b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-fs-e2b",
   "description": "E2B filesystem implementation for Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/e2b/subprocess-e2b/package.json
+++ b/packages/e2b/subprocess-e2b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subprocess-e2b",
   "description": "E2B subprocess implementation for Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/examples/acp-demo/package.json
+++ b/packages/examples/acp-demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-acp-demo",
   "description": "ACP automation server app: agent spine + JSONL persistence + ACP transport, with a JSON-RPC stdio bin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/examples/agent-spine-demo/package.json
+++ b/packages/examples/agent-spine-demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-agent-spine-demo",
   "description": "The default executor-less/UI-less agent spine with fallback session titles, provider-routed retry, and optional persisted goals",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/examples/jsonrpc-demo/package.json
+++ b/packages/examples/jsonrpc-demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-sdk-jsonrpc-demo",
   "description": "Bin that boots an external Cordis config for the stdio JSON-RPC SDK runtime",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/experimental/agent-team/package.json
+++ b/packages/experimental/agent-team/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-experimental-agent-team",
   "description": "Implicit-root Agent Teams roster, durable peer mailbox, and shared task DAG",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/experimental/tool-agent-team/package.json
+++ b/packages/experimental/tool-agent-team/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-experimental-tool-agent-team",
   "description": "Scoped model-facing Agent Teams tools over ctx.agentTeams",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/extensions/cordis-client-runner/package.json
+++ b/packages/extensions/cordis-client-runner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-cordis-client-runner",
   "description": "Browser half of dynamic dual-half plugin packages: event subscription, closure evaluation, guard facade, and loader entries",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/cordis-host-runner/package.json
+++ b/packages/extensions/cordis-host-runner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-cordis-host-runner",
   "description": "Dynamic package definition registry, host-half sandbox lifecycle, and invoke handler table for model-mounted dual-half packages",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/tool-cordis/package.json
+++ b/packages/extensions/tool-cordis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-cordis",
   "description": "Self-referential cordis toolset: inspect the live runtime, mount and dispose model-written plugins",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/extensions/ui-cordis/package.json
+++ b/packages/extensions/ui-cordis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-ui-cordis",
   "description": "Cordis dynamic-plugin definition card: the keyed cordis_define tool row with its run/stop switch",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/feedback/command-feedback/package.json
+++ b/packages/feedback/command-feedback/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-command-feedback",
   "description": "Log-only session feedback producer and human-facing slash command",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/feedback/message-feedback/package.json
+++ b/packages/feedback/message-feedback/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-message-feedback",
   "description": "Lifecycle-bound per-message rating and note sidecar for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fs/fs-local/package.json
+++ b/packages/fs/fs-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-fs-local",
   "description": "Local-filesystem implementation of the Alego filesystem seam (ctx.fs)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fs/fs-observation-policy/package.json
+++ b/packages/fs/fs-observation-policy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-fs-observation-policy",
   "description": "File-context policy plugin for the Alego — observed-state, read-before-edit, and version-guarded write/edit added over the ctx.fs provider seam through the fs/* event gate (no service API)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fs/fs-sandbox/package.json
+++ b/packages/fs/fs-sandbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-fs-sandbox",
   "description": "Sandbox-enforcing implementation of the Alego filesystem seam: fences write/edit by the per-call sandbox mode (read-only denies mutation, workspace-write contains it to the workspace + temp roots) while reads pass through",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fs/fs/package.json
+++ b/packages/fs/fs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-fs",
   "description": "Abstract filesystem capability seam (ctx.fs) for the Alego — vocabulary types, the FileSystem service (text IO + optional version-guarded atomic mutations), and the fs/* policy event vocabulary",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fs/tool-fs-search/package.json
+++ b/packages/fs/tool-fs-search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-fs-search",
   "description": "Model-facing filesystem discovery tools (glob, grep) backed by the packaged ripgrep binary (@vscode/ripgrep)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fs/tool-fs/package.json
+++ b/packages/fs/tool-fs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-fs",
   "description": "Model-facing filesystem tools (read, write, edit) over the Alego filesystem seam (ctx.fs)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fs/tool-str-replace-editor/package.json
+++ b/packages/fs/tool-str-replace-editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-str-replace-editor",
   "description": "Model-facing view, create, literal replace, and line insert tool over the Harness filesystem service",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/goal/command-goal/package.json
+++ b/packages/goal/command-goal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-command-goal",
   "description": "Human-facing slash command for persisted same-session goals",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/goal/goal-round-driver/package.json
+++ b/packages/goal/goal-round-driver/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-goal-round-driver",
   "description": "Race-fenced same-session goal-round driver",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/goal/goal/package.json
+++ b/packages/goal/goal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-goal",
   "description": "Event-sourced same-session goal state and lifecycle service for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/goal/tool-goal/package.json
+++ b/packages/goal/tool-goal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-goal",
   "description": "Model-facing same-session goal tools with execution-time authority checks",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/guard/repeat-tool-reminder/package.json
+++ b/packages/guard/repeat-tool-reminder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-repeat-tool-reminder",
   "description": "Repeat-tool-call guard plugin: advisory reminders when an agent loops on identical tool calls",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/guard/timeout-policy/package.json
+++ b/packages/guard/timeout-policy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-call-timeout-policy",
   "description": "Tool-call timeout policy: a tools/execute wrapper that arms a per-tool deadline on exec.signal and returns TOOL_TIMEOUT when it wins",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/hooks/hook-protocol/package.json
+++ b/packages/hooks/hook-protocol/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-hook-protocol",
   "description": "Shared Claude Code / Codex hook wire protocol: matcher engine, stdin/exit-code/stdout codec, multi-hook merge, and hook/* session events",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/hooks/hooks-claude-code/package.json
+++ b/packages/hooks/hooks-claude-code/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-hooks-claude-code",
   "description": "Bridge plugin: run a Claude Code hooks.json / settings hook config on the Alego interception seams",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/hooks/hooks-codex/package.json
+++ b/packages/hooks/hooks-codex/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-hooks-codex",
   "description": "Bridge plugin: run a Codex hooks.json hook config on the Alego interception seams",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/host/apiproxy/package.json
+++ b/packages/host/apiproxy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-host-apiproxy",
   "description": "API gateway: the ApiProxy contract (api/), the fetch carrier pair (fetch/), and the host-side gateway plugin providing ctx.apiProxy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/host/directory-picker-auto/package.json
+++ b/packages/host/directory-picker-auto/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-host-directory-picker-auto",
   "description": "Adaptive chooser of the directory-picker seam: resolves the host situation at boot and mounts the native or browse backend for the Alego web GUI host",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/host/directory-picker-browse/package.json
+++ b/packages/host/directory-picker-browse/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-host-directory-picker-browse",
   "description": "In-app browsing backend of the directory-picker seam (listing/creation primitives over the host filesystem)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/host/directory-picker-native/package.json
+++ b/packages/host/directory-picker-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-host-directory-picker-native",
   "description": "Native-OS-chooser backend of the directory-picker seam for the Alego web GUI host",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/host/directory-picker/package.json
+++ b/packages/host/directory-picker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-host-directory-picker",
   "description": "Abstract workspace-directory picking seam (ctx.directoryPicker) for the Alego web GUI host",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/host/frontend-static/package.json
+++ b/packages/host/frontend-static/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-host-frontend-static",
   "description": "SPA dist server for the Web shell: owns the webserver fallback seat, serving explicit index entries and static assets with traversal rejection and 404 misses",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/host/plugin-inventory/package.json
+++ b/packages/host/plugin-inventory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-host-plugin-inventory",
   "description": "Read-only Remote projection of current Cordis Loader plugin state",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/host/webserver/package.json
+++ b/packages/host/webserver/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-host-webserver",
   "description": "Web route-registration plugin: HTTP and upgrade routes, index transform taps, and static dist fallback; knows no harness concepts",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/identity/anonymous-user-id/package.json
+++ b/packages/identity/anonymous-user-id/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-anonymous-user-id",
   "description": "Shared anonymous user identity for Alego telemetry and feedback correlation",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/interaction/commands/package.json
+++ b/packages/interaction/commands/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-commands",
   "description": "Plugin-owned human command registry for Alego UIs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/interaction/permission-presets/package.json
+++ b/packages/interaction/permission-presets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-permission-presets",
   "description": "User-facing permission presets (ctx.permissionPresets) for the Alego: one product-level Permissions select bundling the sandbox-mode and approval-policy knobs, written through to their own session events",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/interaction/tool-ask-user/package.json
+++ b/packages/interaction/tool-ask-user/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-ask-user",
   "description": "Model-facing ask_user_question tool over the ctx.userQuestions seam",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/interaction/user-approval/package.json
+++ b/packages/interaction/user-approval/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-user-approval",
   "description": "User-approval seam (ctx.approval) for the Alego: one-shot permission decisions dispatched to composed answerers over the approval/request waterfall, fail-closed by default",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/interaction/user-questions/package.json
+++ b/packages/interaction/user-questions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-user-questions",
   "description": "Abstract user-questions seam (ctx.userQuestions) for asking the human during agent runs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/jobs/jobs-local/package.json
+++ b/packages/jobs/jobs-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-jobs-local",
   "description": "Process-local implementation of the Alego background job registry seam",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/jobs/jobs/package.json
+++ b/packages/jobs/jobs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-jobs",
   "description": "Background job registry (ctx.jobs) for the Alego — shared ids, owner isolation, polling, cancellation, and completion listeners for long-running tool work",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/jobs/tool-jobs/package.json
+++ b/packages/jobs/tool-jobs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-jobs",
   "description": "Model-facing background job control tools (job_output, job_list, job_kill) over the ctx.jobs registry",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/llm/llm-deepseek/package.json
+++ b/packages/llm/llm-deepseek/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-llm-deepseek",
   "description": "DeepSeek chat-completions adapter for the Alego LLM seam",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/llm/llm-pi-ai/package.json
+++ b/packages/llm/llm-pi-ai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-llm-pi-ai",
   "description": "pi-ai-backed DeepSeek adapter for the Alego LLM seam (design-verification twin of alego-llm-deepseek)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/llm/llm-retry/package.json
+++ b/packages/llm/llm-retry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-llm-retry",
   "description": "Provider-routed LLM request retry policy for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/llm/llm/package.json
+++ b/packages/llm/llm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-llm",
   "description": "Provider-neutral LLM service interface for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/llm/token-meter/package.json
+++ b/packages/llm/token-meter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-token-meter",
   "description": "Replay-aware token measurement service (ctx.tokenMeter) for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/lsp/lsp-stdio/package.json
+++ b/packages/lsp/lsp-stdio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-lsp-stdio",
   "description": "Generic stdio language-server provider for the Alego LSP capability seam (ctx.lsp) — spawns configured servers, translates JSON-RPC, and serves transient-open goToDefinition/findReferences/goToImplementation/hover queries in the host filesystem namespace",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/lsp/lsp/package.json
+++ b/packages/lsp/lsp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-lsp",
   "description": "Abstract LSP capability seam (ctx.lsp) for the Alego — language-server provider registry keyed by branded id and extension mapping, order-independent per-query selection, normalized definition/references/implementation/hover requests and results, and the LspError taxonomy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/lsp/tool-lsp/package.json
+++ b/packages/lsp/tool-lsp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-lsp",
   "description": "Model-facing lsp tool over the Alego LSP capability seam (ctx.lsp) — one read-only tool with goToDefinition/findReferences/goToImplementation/hover operations, one-based UTF-16 cursor coordinates, bounded location rendering, and hover normalization",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/mcp/mcp-client/package.json
+++ b/packages/mcp/mcp-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-mcp-client",
   "description": "MCP client bridge: connects to MCP servers and registers their tools on ctx.tools",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plan/plan-mode/package.json
+++ b/packages/plan/plan-mode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-plan-mode",
   "description": "Logged per-agent plan mode with deployment guidance, a direct slash command, and a user-reviewed exit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/preset/agent-presets/package.json
+++ b/packages/preset/agent-presets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-agent-presets",
   "description": "Per-session agent composition from preset cordis.yml files for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/preset/persona/package.json
+++ b/packages/preset/persona/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-persona",
   "description": "Composition-authored deployment persona section for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/runtime-diagnostics/invariants/package.json
+++ b/packages/runtime-diagnostics/invariants/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-invariants",
   "description": "Registry service for package-owned Alego runtime invariants",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sandbox/sandbox-local/package.json
+++ b/packages/sandbox/sandbox-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-sandbox-local",
   "description": "Local process-sandbox backends for the Alego sandbox seam: bwrap, the npm-distributed landlock-run launcher, macOS Seatbelt, or the Windows ACL restricted-token runner — functionally probed, fail-closed",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sandbox/sandbox-policy/package.json
+++ b/packages/sandbox/sandbox-policy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-sandbox-policy",
   "description": "Per-call sandbox policy resolver and current model context: deployment fallbacks plus each session's mode and workspace root, shared by every enforcing capability family",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sandbox/sandbox-windows-acl/package.json
+++ b/packages/sandbox/sandbox-windows-acl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-sandbox-windows-acl",
   "description": "Windows ACL write-restriction sandbox backend (restricted-token spawn with capability-SID write allowlist) for the Alego sandbox seam",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sandbox/sandbox/package.json
+++ b/packages/sandbox/sandbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-sandbox",
   "description": "Abstract process-sandbox seam (ctx.sandbox) for the Alego: same-world confinement vocabulary and the SandboxProvider contract",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/schedule/schedule/package.json
+++ b/packages/schedule/schedule/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-schedule",
   "description": "Agent-scoped durable after, at, and fixed-rate reminders over the session event log",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sdk/client/package.json
+++ b/packages/sdk/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-sdk-client",
   "description": "TypeScript client SDK for driving an Alego runtime subprocess over stdio JSON-RPC: the Alego high-level turns API and the lower-level HarnessClient",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sdk/protocol/package.json
+++ b/packages/sdk/protocol/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-sdk-protocol",
   "description": "Shared wire protocol for the Alego SDK runtime: the newline-delimited JSON-RPC stdio transport and the named request, result, and notification types spoken between the runtime server and SDK clients",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sdk/server/package.json
+++ b/packages/sdk/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-sdk-jsonrpc-server",
   "description": "Stdio JSON-RPC server plugin for out-of-process Alego SDK clients",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session-query/session-log-export/package.json
+++ b/packages/session-query/session-log-export/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-log-export",
   "description": "Web Session-log export command and shared download dialog",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": { "access": "public" },
   "repository": {
     "type": "git",

--- a/packages/session-query/session-query-sqlite/package.json
+++ b/packages/session-query/session-query-sqlite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-query-sqlite",
   "description": "Concrete ctx.sessionQuery backend with SQLite FTS5 search",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session-query/session-query/package.json
+++ b/packages/session-query/session-query/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-query",
   "description": "Combined session query service contract with concrete reads, traces, and filters",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session-query/tool-session-query/package.json
+++ b/packages/session-query/tool-session-query/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-session-query",
   "description": "Workspace-authorized model-facing session history search, trace, and event read tools",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-checkpoint-policy/package.json
+++ b/packages/session/session-checkpoint-policy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-checkpoint-policy",
   "description": "Semantic session durability checkpoints before model requests and tool side effects",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-persistence-jsonl/package.json
+++ b/packages/session/session-persistence-jsonl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-persistence-jsonl",
   "description": "JSONL durable session persistence backend for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-persistence-sqlite/package.json
+++ b/packages/session/session-persistence-sqlite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-persistence-sqlite",
   "description": "SQLite durable session persistence with physical chunk-row packing",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-persistence/package.json
+++ b/packages/session/session-persistence/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-persistence",
   "description": "Abstract durable session persistence seam (ctx.sessionPersistence) for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-projection-cache/package.json
+++ b/packages/session/session-projection-cache/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-projection-cache",
   "description": "Persisted projection cache (ctx.sessionProjectionCache): durable per-session projection checkpoints over the domain data form, throttled write-behind, and the cold-read ladder (cache row + persistence tail replay)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-projection/package.json
+++ b/packages/session/session-projection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-projection",
   "description": "Session-projection seam: the merge-extensible projection type table, the provider contract, and the ctx.sessionProjections registry serving whole current values of log-derived per-session state",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-stats/package.json
+++ b/packages/session/session-stats/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-stats",
   "description": "Whole-log conversation counts and wall times projection (sessionStats) for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-telemetry-otel/package.json
+++ b/packages/session/session-telemetry-otel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-telemetry-otel",
   "description": "OpenTelemetry backend for the Alego telemetry seam: hands captured session records to the OTel JS SDK's log pipeline",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-telemetry/package.json
+++ b/packages/session/session-telemetry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-telemetry",
   "description": "SessionTelemetryBackend seam for the Alego: session-event capture, projection, redaction, and handoff to a reporting backend",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-title-all-prompts-llm/package.json
+++ b/packages/session/session-title-all-prompts-llm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-title-all-prompts-llm",
   "description": "All-user-messages LLM provider plugin for Alego session titles",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-title-first-prompt-llm/package.json
+++ b/packages/session/session-title-first-prompt-llm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-title-first-prompt-llm",
   "description": "First-message LLM provider plugin for Alego session titles",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-title-llm/package.json
+++ b/packages/session/session-title-llm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-title-llm",
   "description": "Shared LLM generation policy for Alego session-title providers",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/session/session-title/package.json
+++ b/packages/session/session-title/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-session-title",
   "description": "Log-backed session title service and provider registry for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/settings/settings-file/package.json
+++ b/packages/settings/settings-file/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-settings-file",
   "description": "File-backed settings provider (settings.yaml) for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/settings/settings/package.json
+++ b/packages/settings/settings/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-settings",
   "description": "Abstract user-settings seam (ctx.settings) for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/bash-local/package.json
+++ b/packages/shell/bash-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-bash-local",
   "description": "Local-subprocess implementation of the Alego bash executor seam",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/bash-sandbox/package.json
+++ b/packages/shell/bash-sandbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-bash-sandbox",
   "description": "Sandbox-consuming implementation of the Alego bash executor seam (confines every command via ctx.sandbox, reports denial/enforcement result facts)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/pwsh-local/package.json
+++ b/packages/shell/pwsh-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-pwsh-local",
   "description": "Local PowerShell implementation of the Alego bash executor seam",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/pwsh-sandbox/package.json
+++ b/packages/shell/pwsh-sandbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-pwsh-sandbox",
   "description": "Sandbox-consuming implementation of the Alego PowerShell executor seam (confines every command via ctx.sandbox, reports denial/enforcement result facts)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/shell-env/package.json
+++ b/packages/shell/shell-env/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-shell-env",
   "description": "Tool-independent managed ALEGO_* shell environment registry",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/shell/package.json
+++ b/packages/shell/shell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-shell",
   "description": "Abstract bash executor seam (ctx.shell) for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/tool-bash-persistent/package.json
+++ b/packages/shell/tool-bash-persistent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-bash-persistent",
   "description": "Model-facing owner-scoped persistent Bash tool backed by the Harness PTY service",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/tool-bash/package.json
+++ b/packages/shell/tool-bash/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-bash",
   "description": "Model-facing bash tool with optional generic background-job and sandbox-escalation support",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/tool-pwsh-persistent/package.json
+++ b/packages/shell/tool-pwsh-persistent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-pwsh-persistent",
   "description": "Model-facing owner-scoped persistent PowerShell tool backed by the Harness PTY service",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/shell/tool-pwsh/package.json
+++ b/packages/shell/tool-pwsh/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-pwsh",
   "description": "Model-facing pwsh tool over the bash executor seam",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/skill/skill-badge/package.json
+++ b/packages/skill/skill-badge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-skill-badge",
   "description": "Bundled alego badge skill provider for Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/skill/skill-filesystem/package.json
+++ b/packages/skill/skill-filesystem/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-skill-filesystem",
   "description": "Local filesystem skill provider for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/skill/skill/package.json
+++ b/packages/skill/skill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-skill",
   "description": "Agent skill provider registry for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/skill/tool-skill/package.json
+++ b/packages/skill/tool-skill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-skill",
   "description": "Model-facing skill loading tool for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/spill/spill-local/package.json
+++ b/packages/spill/spill-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-spill-local",
   "description": "Local-filesystem implementation of the Alego spill storage seam (private session-scoped files)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/spill/spill-policy/package.json
+++ b/packages/spill/spill-policy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-spill-policy",
   "description": "Tool-result spill policy for the Alego — replaces oversized plain-text tool results with a retained preview plus a spill-file path (no service API)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/spill/spill/package.json
+++ b/packages/spill/spill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-spill",
   "description": "Abstract spill storage seam (ctx.spillStore) for the Alego — save oversized tool text and return a retrieval locator",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/storage/storage-domain/package.json
+++ b/packages/storage/storage-domain/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-storage-domain",
   "description": "Domain data form (ctx.storage.domain): schema-validated, event-emitting KV domains over storage backends for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/storage/storage-json/package.json
+++ b/packages/storage/storage-json/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-storage-json",
   "description": "JSON file KV storage backend for the Alego storage hub",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/storage/storage-sqlite/package.json
+++ b/packages/storage/storage-sqlite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-storage-sqlite",
   "description": "SQLite storage backend (kv facet) for the Alego storage hub",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/storage/storage/package.json
+++ b/packages/storage/storage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-storage",
   "description": "Storage hub (ctx.storage): named backend registry plus mounted data-form facilities for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/subagent-acp/package.json
+++ b/packages/subagent/subagent-acp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subagent-acp",
   "description": "Out-of-process ACP subagent backend: drives a child agent in a spawned subprocess over the Agent Client Protocol",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/subagent-alego-sdk/package.json
+++ b/packages/subagent/subagent-alego-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subagent-alego-sdk",
   "description": "Out-of-process SDK subagent backend: drives a child Alego runtime subprocess over stdio JSON-RPC through the TypeScript SDK client",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/subagent-claude-code/package.json
+++ b/packages/subagent/subagent-claude-code/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subagent-claude-code",
   "description": "One-shot Claude Code subagent provider over the official Agent SDK",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/subagent-codex/package.json
+++ b/packages/subagent/subagent-codex/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subagent-codex",
   "description": "One-shot Codex subagent provider over the official app-server protocol",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/subagent-fork-in-process/package.json
+++ b/packages/subagent/subagent-fork-in-process/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subagent-fork-in-process",
   "description": "In-process fork subagent backend: runs a child agent seeded with a prefix of the parent's log",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/subagent-in-process-driver/package.json
+++ b/packages/subagent/subagent-in-process-driver/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subagent-in-process-driver",
   "description": "Shared in-process subagent run driver: drives a child agent on ctx.agents (used by the spawn and fork backends)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/subagent-spawn-in-process/package.json
+++ b/packages/subagent/subagent-spawn-in-process/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subagent-spawn-in-process",
   "description": "In-process spawn subagent backend: runs a fresh child agent on ctx.agents",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/subagent/package.json
+++ b/packages/subagent/subagent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subagent",
   "description": "Abstract subagent seam (ctx.subagents): named-provider registry for delegating to child agents",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/tool-subagent-control/package.json
+++ b/packages/subagent/tool-subagent-control/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-subagent-control",
   "description": "Globally named send_message, interrupt_agent, and list_agents tools over ctx.subagents continuations",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/tool-subagent-report/package.json
+++ b/packages/subagent/tool-subagent-report/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-subagent-report",
   "description": "Child-scoped report tool over ctx.subagents continuations",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subagent/tool-subagent/package.json
+++ b/packages/subagent/tool-subagent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-subagent",
   "description": "Model-facing subagent delegation tool over the ctx.subagents seam",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subprocess/subprocess-local/package.json
+++ b/packages/subprocess/subprocess-local/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subprocess-local",
   "description": "Local-subprocess implementation of the Alego subprocess seam",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/subprocess/subprocess/package.json
+++ b/packages/subprocess/subprocess/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-subprocess",
   "description": "Subprocess seam (ctx.subprocess) for the Alego — managed process groups, bounded spill-backed output, and escalated kills behind one abstract service",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/terminal/terminal-bash/package.json
+++ b/packages/terminal/terminal-bash/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-terminal-bash",
   "description": "Persistent shell PTY backend over the Alego subprocess terminal primitive",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/terminal/terminal/package.json
+++ b/packages/terminal/terminal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-terminal",
   "description": "Persistent PTY session seam for the Alego — owner-scoped ids, backend registry, interactive sends, reads, signals, and awaited cleanup",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/terminal/tool-terminal/package.json
+++ b/packages/terminal/tool-terminal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-terminal",
   "description": "Six model-facing persistent PTY tools with owner isolation and generic background-job integration",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/test-support/acp-snapshot/package.json
+++ b/packages/test-support/acp-snapshot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-acp-snapshot",
   "description": "ACP test kit: shared subprocess launcher, snapshot scenario harness, expected-output normalizers, and suite factory",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/test-support/agent-loop-testkit/package.json
+++ b/packages/test-support/agent-loop-testkit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-agent-loop-testkit",
   "description": "Shared prerequisite mounting for tests that exercise the concrete agent loop",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/test-support/client-runtime/package.json
+++ b/packages/test-support/client-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-client-test-runtime",
   "description": "jsdom slot test runtime: real Cordis Context + SlotRegistry + UI renderer with test-owned session/workspace doubles for feature specs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/test-support/llm-mock-server/package.json
+++ b/packages/test-support/llm-mock-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-llm-mock-server",
   "description": "Scriptable OpenAI-compatible HTTP/SSE fault server for LLM recovery tests",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/test-support/llm-replay/package.json
+++ b/packages/test-support/llm-replay/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-llm-replay",
   "description": "Replay LLM plugin: short-circuits llm/stream with model chunks reconstructed from a recorded session JSONL (keyless snapshot tests)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/test-support/loader-smoke/package.json
+++ b/packages/test-support/loader-smoke/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-loader-smoke",
   "description": "Shared subprocess and direct-agent harness for keyless real-Loader example smoke tests",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/todo/tool-todo/package.json
+++ b/packages/todo/tool-todo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-todo",
   "description": "Model-facing todo_write tool over the Alego event-sourced session log",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/typert/generator/package.json
+++ b/packages/typert/generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-typert-generator",
   "description": "TypeScript project analyzer and model-driven Typert artifact generator",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/typert/loader/package.json
+++ b/packages/typert/loader/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-typert-loader",
   "description": "Loader integration for generated Typert package contributions",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/typert/protocol/package.json
+++ b/packages/typert/protocol/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-typert-protocol",
   "description": "Compiler-independent Remote metadata and Typert provider protocols",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/typert/registry/package.json
+++ b/packages/typert/registry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-typert-registry",
   "description": "Runtime registry for generated package reflection and Zod schemas",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/util/atomic-write/package.json
+++ b/packages/util/atomic-write/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-atomic-write",
   "description": "Zero-dependency atomic file replacement: exclusive-create random-suffix temp + rename carrying the caller-stated permissions (writeFileAtomic)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/util/brand/package.json
+++ b/packages/util/brand/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-brand",
   "description": "Type-only Branded<B> nominal-typing primitive for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/util/home-paths/package.json
+++ b/packages/util/home-paths/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-home-paths",
   "description": "Shared filesystem path helpers for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/util/launch-environment/package.json
+++ b/packages/util/launch-environment/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-launch-environment",
   "description": "Immutable Alego launch environment that records which layer supplied each value",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/util/native-command/package.json
+++ b/packages/util/native-command/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-native-command",
   "description": "Zero-dependency no-shell execFile runner for host-native OS integrations: utf8 stdio capture, abort propagation, Windows hide",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/util/output-retention/package.json
+++ b/packages/util/output-retention/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-output-retention",
   "description": "Zero-dependency bounded-retention primitive: ItemRetainer/TextRetainer + neutral notice helpers (what did we keep, what did we omit)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/util/timeout/package.json
+++ b/packages/util/timeout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-timeout",
   "description": "Zero-dependency timeout/deadline primitive: clampTimeout, deadline, timeoutOf, TimeoutReason (timing + classification only, no termination)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web/tool-web/package.json
+++ b/packages/web/tool-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-web",
   "description": "Model-facing web tools (web_search, web_fetch) over the Alego web capability seam (ctx.web)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web/web-fetch-http/package.json
+++ b/packages/web/web-fetch-http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-web-fetch-http",
   "description": "Anonymous public HTTP(S) fetch provider for the Alego web capability seam (ctx.web)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web/web-search-deepseek/package.json
+++ b/packages/web/web-search-deepseek/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-web-search-deepseek",
   "description": "DeepSeek-backed search provider (native web_search via the Anthropic-compatible API) for the Alego web capability seam (ctx.web)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web/web-search-exa/package.json
+++ b/packages/web/web-search-exa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-web-search-exa",
   "description": "Exa-backed search provider for the Alego web capability seam (ctx.web)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web/web-search-perplexity/package.json
+++ b/packages/web/web-search-perplexity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-web-search-perplexity",
   "description": "Perplexity-backed search provider for the Alego web capability seam (ctx.web)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/web/web/package.json
+++ b/packages/web/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-web",
   "description": "Abstract web access capability seam (ctx.web) for the Alego — search/fetch provider registry, registration-order-independent selection, request/result vocabulary, and the WebError taxonomy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/workflow/tool-ralph/package.json
+++ b/packages/workflow/tool-ralph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-ralph",
   "description": "Model-facing fresh-agent Ralph loop over the workflow and subagent seams",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/workflow/tool-workflow/package.json
+++ b/packages/workflow/tool-workflow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-tool-workflow",
   "description": "Model-facing workflow tool: run a JavaScript orchestration script over ctx.workflowEngine",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/workflow/workflow-worker-thread/package.json
+++ b/packages/workflow/workflow-worker-thread/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-workflow-worker-thread",
   "description": "worker-thread workflow engine: executes model-written orchestration scripts off the host event loop, bridging agent() calls back to ctx.subagents",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/workflow/workflow/package.json
+++ b/packages/workflow/workflow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-workflow",
   "description": "Workflow capability seam: ctx.workflowEngine service, run vocabulary, and workflow/* events",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/workspace/workspace/package.json
+++ b/packages/workspace/workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@singula-ai/alego-workspace",
   "description": "Workspace entity registry (ctx.workspaceRegistry): durable workspace records with validated session attachment over the domain data form for the Alego",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/scripts/release/publish.spec.ts
+++ b/scripts/release/publish.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { publishRetryDirective } from './publish.ts'
+
+const E429 = 'npm error code E429\nnpm error 429 Too Many Requests - PUT … rate limited exceeded'
+const E409 = 'npm error code E409\nnpm error Failed to save packument'
+const E403 = 'npm error code E403\nnpm error You cannot publish over the previously published versions'
+
+describe('publishRetryDirective', () => {
+  it('waits minutes for a rate limit and gives up on the sixth attempt', () => {
+    expect([0, 1, 2, 3, 4].map(prior => publishRetryDirective(E429, 0, prior)?.delayMs))
+      .toEqual([60_000, 120_000, 240_000, 480_000, 960_000])
+    expect(publishRetryDirective(E429, 0, 5)).toBeUndefined()
+  })
+
+  it('keeps the seconds ladder for packument settling and gives up on the fourth attempt', () => {
+    expect([0, 1, 2].map(prior => publishRetryDirective(E409, prior, 0)?.delayMs))
+      .toEqual([2_000, 4_000, 8_000])
+    expect(publishRetryDirective(E409, 3, 0)).toBeUndefined()
+  })
+
+  it('never retries a rejected payload', () => {
+    expect(publishRetryDirective(E403, 0, 0)).toBeUndefined()
+  })
+
+  it('tracks the two budgets independently', () => {
+    // Exhausted settling attempts leave the full rate-limit budget, and the reverse.
+    expect(publishRetryDirective(E429, 3, 0)?.delayMs).toBe(60_000)
+    expect(publishRetryDirective(E409, 0, 5)?.delayMs).toBe(2_000)
+  })
+
+  it('labels each directive with its own budget', () => {
+    expect(publishRetryDirective(E429, 0, 0)).toMatchObject({ rateLimited: true, attempt: 1, budget: 6 })
+    expect(publishRetryDirective(E409, 1, 0)).toMatchObject({ rateLimited: false, attempt: 2, budget: 4 })
+  })
+})

--- a/scripts/release/publish.ts
+++ b/scripts/release/publish.ts
@@ -30,8 +30,25 @@ import { packedIdentity, readPublishOrder } from './tarball.ts'
  */
 const TRANSIENT_PUBLISH_CODES = ['E409', 'E429', 'E500', 'E502', 'E503', 'E504', 'ETIMEDOUT', 'ECONNRESET', 'EAI_AGAIN'] as const
 
-/** How many times one tarball's publish is attempted before the run fails. */
+/** How many times one tarball's publish is attempted for a transient failure other than a rate limit. */
 const PUBLISH_ATTEMPTS = 4
+
+/**
+ * Attempts and first backoff for a rate-limited publish (`E429`).
+ *
+ * The registry meters new-package creation over windows of minutes, not
+ * seconds: the first alego release saw `E429` persist across retries spaced
+ * 2–8 seconds while npm's own in-client retries had already waited about a
+ * minute per invocation, so a short ladder turns one metering window into a
+ * failed run. Five doubling waits from one minute total ~31 minutes — long
+ * enough to ride out metering, while a hard quota still fails within the
+ * publish job's time budget
+ * ([incident](../../.agents/notes/implemented/process/2026-08-24-npm-publish-rate-limit-recovery.md)).
+ */
+const RATE_LIMIT_ATTEMPTS = 6
+
+/** First wait after a rate-limited attempt; each further wait doubles it. */
+const RATE_LIMIT_BACKOFF_MS = 60_000
 
 /**
  * Shortest gap between two publishes, and the first retry backoff.
@@ -94,10 +111,52 @@ function registryState(name: string, version: string): RegistryState {
  * @param name - package name the tarball declares.
  * @param version - package version the tarball declares.
  */
+/** One retryable failed publish attempt: how long to wait, and under which budget. */
+export interface PublishRetryDirective {
+  /** Milliseconds to wait before the next attempt. */
+  readonly delayMs: number
+  /** True when the failure was the registry's rate limit rather than another transient code. */
+  readonly rateLimited: boolean
+  /** One-based number of the attempt that just failed, within its budget. */
+  readonly attempt: number
+  /** Total attempts that budget allows. */
+  readonly budget: number
+}
+
+/**
+ * Decide whether a failed publish attempt is retried, and after how long.
+ *
+ * A rate limit waits minutes on its own budget, because the registry meters
+ * new-package creation over windows that outlast the seconds-scale ladder;
+ * every other transient code keeps the short ladder that answers `E409`
+ * packument settling. The two budgets are independent, so metering cannot
+ * consume the settling attempts nor the reverse.
+ * @param output - combined npm output of the failed attempt.
+ * @param transientFailures - prior failed attempts with a non-rate-limit transient code.
+ * @param rateLimitedFailures - prior failed attempts with `E429`.
+ * @returns The retry directive, or undefined when the failure is terminal — a
+ * non-transient code, or the matching budget is exhausted.
+ */
+export function publishRetryDirective(
+  output: string,
+  transientFailures: number,
+  rateLimitedFailures: number,
+): PublishRetryDirective | undefined {
+  if (!isTransientFailure(output)) return undefined
+  const rateLimited = output.includes('code E429')
+  const attempt = (rateLimited ? rateLimitedFailures : transientFailures) + 1
+  const budget = rateLimited ? RATE_LIMIT_ATTEMPTS : PUBLISH_ATTEMPTS
+  if (attempt >= budget) return undefined
+  const base = rateLimited ? RATE_LIMIT_BACKOFF_MS : PUBLISH_SPACING_MS
+  return { delayMs: base * 2 ** (attempt - 1), rateLimited, attempt, budget }
+}
+
 async function publishTarball(tarball: string, name: string, version: string): Promise<void> {
   // A prerelease version never takes the latest dist-tag.
   const tagArgs = version.includes('-') ? ['--tag', 'next'] : []
-  for (let tries = 1; tries <= PUBLISH_ATTEMPTS; tries += 1) {
+  let transientFailures = 0
+  let rateLimitedFailures = 0
+  for (;;) {
     // No --access: the sequences do not share one access level, so a
     // command-line flag could not serve both and would override the manifest
     // that does. Each packed manifest decides, and
@@ -111,15 +170,17 @@ async function publishTarball(tarball: string, name: string, version: string): P
       console.log(`release publish: ${name}@${version} landed despite a reported failure, continuing`)
       return
     }
-    if (tries === PUBLISH_ATTEMPTS || !isTransientFailure(output)) {
+    const retry = publishRetryDirective(output, transientFailures, rateLimitedFailures)
+    if (retry === undefined) {
       throw new Error(`npm publish ${name}@${version} failed:\n${output}`)
     }
-    const backoff = PUBLISH_SPACING_MS * 2 ** (tries - 1)
+    if (retry.rateLimited) rateLimitedFailures += 1
+    else transientFailures += 1
     console.log(
-      `release publish: ${name}@${version} hit a transient registry failure`
-      + ` (attempt ${String(tries)} of ${String(PUBLISH_ATTEMPTS)}), retrying in ${String(backoff)}ms`,
+      `release publish: ${name}@${version} ${retry.rateLimited ? 'is rate limited' : 'hit a transient registry failure'}`
+      + ` (attempt ${String(retry.attempt)} of ${String(retry.budget)}), retrying in ${String(retry.delayMs)}ms`,
     )
-    await sleep(backoff)
+    await sleep(retry.delayMs)
   }
 }
 


### PR DESCRIPTION
Issue: none.

<details>
<summary>Changes and verification</summary>

Two commits.

**`80569db4` — rate-limited publishes get their own minutes-scale retry budget.** The 0.1.1 publication failed 13/227 members in when the registry's meter on new-package creation outlasted the seconds-scale retry ladder. `publishTarball` now keeps two independent budgets: `E429` waits on five doubling backoffs from one minute (~31 min total); every other transient code keeps the existing `E409`-settling ladder. The judgement is the exported pure `publishRetryDirective` with its own spec. Agent Note (bilingual): `2026-08-24-npm-publish-rate-limit-recovery` — including why re-running the publish job, never a fresh dispatch, is the resume path while builds are not byte-reproducible.

**`7eccdfc0` — `release(alego): 0.1.2`.** 0.1.1 is unreleasable: 13 members are on the registry with tarball bytes from an abandoned lineage, and the non-reproducible build means any new pack of 0.1.1 fails the integrity guard against them. Produced by `pnpm run release:alego 0.1.2`.

**Verification**

- `vitest run scripts/release/` — 30/30 (families + new publish spec).
- `release:verify --family alego` — 227 members, one shared version 0.1.2, publish order resolved.
- `verify-agent-note-format`, `verify-agent-note-classification`, `verify-translation-pairing` (1006 pairs), `verify-md-wrap`, `verify-md-links` — pass.
- oxlint on changed files clean; pre-commit hooks passed.

Known check state: four CI jobs target larger-runner labels unavailable on this plan and queue forever; `Release (alego)` is the meaningful gate for this change.

</details>
