### PR TITLE
Add a one-command source install

### DIFF
--- a/.agents/notes/implemented/process/2026-08-27-curl-source-install.i18n.yaml
+++ b/.agents/notes/implemented/process/2026-08-27-curl-source-install.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/process/2026-08-27-curl-source-install.md
+2026-08-27-curl-source-install.md: f188c243f5db13b5ebec97457f48da6446f27caa
+2026-08-27-curl-source-install.zh.md: 51261739f0fef15d92b93d03def22cbb37cde572

--- a/.agents/notes/implemented/process/2026-08-27-curl-source-install.md
+++ b/.agents/notes/implemented/process/2026-08-27-curl-source-install.md
@@ -1,0 +1,29 @@
+# Agent Note: One-command source install through a PATH launcher
+
+Status: implemented
+
+English | [中文](2026-08-27-curl-source-install.zh.md)
+
+## Problem
+
+The repository documents `npx @singula-ai/alego web` as the front door, but the registry cannot yet serve it: the alego family publishes name-by-name under the registry's 25-new-names-per-day account limit, and until `@singula-ai/alego` itself lands the whole npm route resolves nothing. Running from source worked but took five manual steps, and "install this from GitHub" had no answer a README can hand to someone in one line.
+
+## Decision
+
+A root [`install.sh`](../../../../install.sh), run as `curl -fsSL https://raw.githubusercontent.com/singula-ai/alego/main/install.sh | bash`, performs the supported source setup end to end: verify `git` and the engines range (`^22.19.0 || >=24`), provide pnpm through `corepack enable` when absent so the `packageManager` pin decides the version, clone `--depth 1` into `ALEGO_SRC_DIR` (default `~/.alego-src`, deliberately not `~/.alego`, which the runtime owns), `pnpm install --frozen-lockfile`, full `pnpm run build`, and write a two-line launcher into `ALEGO_BIN_DIR` (default `~/.local/bin`) that execs `node <checkout>/apps/cli/lib/bin.js`. Re-running fetches the ref and rebuilds; local edits inside the managed checkout are discarded on update, which the script announces. `ALEGO_REPO` and `ALEGO_REF` select fork and branch.
+
+The global command is a written launcher rather than a package-manager link. `pnpm link --global` requires a configured global bin directory (`pnpm setup` / `PNPM_HOME`) and fails with `ERR_PNPM_NO_GLOBAL_BIN_DIR` on machines that never ran it, and `npm link` tries to install `apps/cli` in isolation, where its `workspace:^` ranges resolve nowhere. A launcher file depends only on `PATH`, and the script says so when the bin directory is not on it.
+
+## Alternatives considered
+
+**Waiting for the npm rollout.** The registry limit makes that days away, and the source path stays worth one command afterwards — for unreleased branches, forks, and contributors.
+
+**`pnpm link --global` / `npm link`.** Rejected for the failure modes above; both also bind the command to package-manager global state that differs per machine, while a launcher is inspectable with `cat`.
+
+**Installing prebuilt artifacts.** There is no released artifact channel to fetch from yet; the packed tarballs live behind the same registry limit.
+
+## Consequences
+
+- Linux and macOS only; Windows keeps the npm route and the manual checkout. The script is bash and never elevates: everything lands under `$HOME`.
+- The launcher hardwires the checkout path, so moving `ALEGO_SRC_DIR` means re-running the installer.
+- Verified end to end on a clean prefix: anonymous clone of the public repository, frozen install, full build, and `alego --version` through the written launcher.

--- a/.agents/notes/implemented/process/2026-08-27-curl-source-install.zh.md
+++ b/.agents/notes/implemented/process/2026-08-27-curl-source-install.zh.md
@@ -1,0 +1,29 @@
+# Agent Note：经 PATH 启动器的一条命令源码安装
+
+Status: implemented
+
+[English](2026-08-27-curl-source-install.md) | 中文
+
+## Problem
+
+仓库文档以 `npx @singula-ai/alego web` 作为入口，但 registry 目前无法提供它：alego 族在 registry 每账号每天 25 个新包名的限制下逐名发布，在 `@singula-ai/alego` 本身落地之前，整条 npm 路径解析不到任何东西。从源码运行虽然可行，却需要五步手工操作，而"从 GitHub 装上它"没有一个 README 能一行递给别人的答案。
+
+## Decision
+
+根目录 [`install.sh`](../../../../install.sh) 以 `curl -fsSL https://raw.githubusercontent.com/singula-ai/alego/main/install.sh | bash` 运行，端到端完成受支持的源码安装：校验 `git` 与 engines 范围（`^22.19.0 || >=24`），缺少 pnpm 时通过 `corepack enable` 提供、由 `packageManager` 钉住版本，`--depth 1` 克隆到 `ALEGO_SRC_DIR`（默认 `~/.alego-src`，刻意避开运行时持有的 `~/.alego`），执行 `pnpm install --frozen-lockfile` 与完整 `pnpm run build`，再向 `ALEGO_BIN_DIR`（默认 `~/.local/bin`）写入两行启动器，exec `node <检出>/apps/cli/lib/bin.js`。重复运行会拉取 ref 并重新构建；受管检出内的本地修改在更新时被丢弃，脚本会予以声明。`ALEGO_REPO` 与 `ALEGO_REF` 用于选择 fork 与分支。
+
+全局命令是写出的启动器文件，而非包管理器链接。`pnpm link --global` 要求已配置全局 bin 目录（`pnpm setup` / `PNPM_HOME`），在从未运行过它的机器上以 `ERR_PNPM_NO_GLOBAL_BIN_DIR` 失败；`npm link` 会孤立地安装 `apps/cli`，其 `workspace:^` 范围在那里无从解析。启动器文件只依赖 `PATH`，且当 bin 目录不在 PATH 上时脚本会明说。
+
+## Alternatives considered
+
+**等待 npm 完成发布。**registry 限制使其还需数日，而源码路径此后仍值得一条命令——用于未发布分支、fork 与贡献者。
+
+**`pnpm link --global` / `npm link`。**因上述失败模式而拒绝；二者还把命令绑定到因机器而异的包管理器全局状态，而启动器用 `cat` 即可查验。
+
+**安装预构建产物。**目前没有可拉取的已发布产物渠道；打包好的 tarball 同样困在该 registry 限制之后。
+
+## Consequences
+
+- 仅支持 Linux 与 macOS；Windows 继续走 npm 路径与手动检出。脚本为 bash 且从不提权：一切落在 `$HOME` 之下。
+- 启动器硬编码检出路径，移动 `ALEGO_SRC_DIR` 意味着重新运行安装器。
+- 已在干净前缀上端到端验证：匿名克隆公开仓库、frozen 安装、完整构建，并通过写出的启动器运行 `alego --version`。

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write README.md
-README.md: cef6dcc2a970f8891ac42e9b82ae2f1adea962f3
-README.zh.md: 6228f69093721fc756715fbca0d8f5cd36867537
+README.md: e1200774926a3aaeb919bfbf3f0529a1d7133f84
+README.zh.md: 698ec8ba1f2c6084f55a2c76041facce1e1df99b

--- a/README.md
+++ b/README.md
@@ -26,7 +26,15 @@ The command starts the Web UI at `http://127.0.0.1:3080` by default and opens it
 
 ### Run from source
 
-To run from a repository checkout:
+One command installs it on Linux/macOS (requires `git` and Node.js `^22.19.0 || >=24`; pnpm is provided through corepack when missing):
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/singula-ai/alego/main/install.sh | bash
+```
+
+The script clones the repository into `~/.alego-src`, installs dependencies, builds the runtime and Web UI, and writes an `alego` launcher into `~/.local/bin`; run `alego web` afterwards. Re-running the same command updates the checkout and rebuilds. `ALEGO_SRC_DIR`, `ALEGO_BIN_DIR`, `ALEGO_REPO`, and `ALEGO_REF` override the defaults; uninstall by removing the launcher and the checkout directory.
+
+To run from a repository checkout manually:
 
 ```sh
 git clone https://github.com/singula-ai/alego.git

--- a/README.zh.md
+++ b/README.zh.md
@@ -30,7 +30,15 @@ npx @singula-ai/alego web
 
 ### 从源码运行
 
-如需从仓库源码运行：
+在 Linux/macOS 上，一条命令即可完成安装（需要 `git` 与 Node.js `^22.19.0 || >=24`；缺少 pnpm 时会通过 corepack 提供）：
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/singula-ai/alego/main/install.sh | bash
+```
+
+该脚本会把仓库克隆到 `~/.alego-src`，安装依赖并构建运行时与 Web UI，然后在 `~/.local/bin` 写入 `alego` 启动器；之后运行 `alego web` 即可。重复运行同一命令会更新检出并重新构建。`ALEGO_SRC_DIR`、`ALEGO_BIN_DIR`、`ALEGO_REPO`、`ALEGO_REF` 可覆盖默认值；卸载时删除启动器和检出目录即可。
+
+如需手动从仓库检出运行：
 
 ```sh
 git clone https://github.com/singula-ai/alego.git

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# One-command source install for the alego CLI (Linux/macOS):
+#
+#   curl -fsSL https://raw.githubusercontent.com/singula-ai/alego/main/install.sh | bash
+#
+# Clones the repository, installs dependencies with the pinned pnpm, builds the
+# runtime and Web UI, and writes an `alego` launcher into a bin directory.
+# Re-running updates the checkout and rebuilds; local changes inside the
+# managed checkout are discarded on update.
+#
+# Environment overrides:
+#   ALEGO_SRC_DIR  checkout directory       (default: ~/.alego-src)
+#   ALEGO_BIN_DIR  launcher directory       (default: ~/.local/bin)
+#   ALEGO_REPO     git URL                  (default: https://github.com/singula-ai/alego.git)
+#   ALEGO_REF      branch or tag to install (default: main)
+#
+# Uninstall: remove "$ALEGO_BIN_DIR/alego" and "$ALEGO_SRC_DIR".
+set -euo pipefail
+
+SRC_DIR="${ALEGO_SRC_DIR:-$HOME/.alego-src}"
+BIN_DIR="${ALEGO_BIN_DIR:-$HOME/.local/bin}"
+REPO="${ALEGO_REPO:-https://github.com/singula-ai/alego.git}"
+REF="${ALEGO_REF:-main}"
+
+info() { printf 'alego install: %s\n' "$*"; }
+fail() { printf 'alego install: error: %s\n' "$*" >&2; exit 1; }
+
+command -v git >/dev/null 2>&1 || fail "git is required"
+command -v node >/dev/null 2>&1 || fail "Node.js is required (^22.19.0 || >=24)"
+
+# The repository's engines range: ^22.19.0 || >=24.
+node_version="$(node --version)"
+node_version="${node_version#v}"
+node_major="${node_version%%.*}"
+node_rest="${node_version#*.}"
+node_minor="${node_rest%%.*}"
+if [ "$node_major" -lt 22 ] || [ "$node_major" -eq 23 ] \
+  || { [ "$node_major" -eq 22 ] && [ "$node_minor" -lt 19 ]; }; then
+  fail "Node.js $node_version is unsupported; alego needs ^22.19.0 || >=24"
+fi
+
+# pnpm, through corepack when absent: corepack ships with Node and provides the
+# pnpm version pinned by the repository's packageManager field.
+if ! command -v pnpm >/dev/null 2>&1; then
+  command -v corepack >/dev/null 2>&1 \
+    || fail "pnpm is required; install it (https://pnpm.io/installation) or provide corepack"
+  info "pnpm not found; enabling it through corepack"
+  corepack enable >/dev/null 2>&1 \
+    || fail "corepack enable failed; install pnpm manually (https://pnpm.io/installation)"
+  hash -r
+  command -v pnpm >/dev/null 2>&1 \
+    || fail "pnpm is still unavailable after corepack enable; install it manually"
+fi
+
+if [ -e "$SRC_DIR" ] && [ ! -d "$SRC_DIR/.git" ]; then
+  fail "$SRC_DIR exists but is not a git checkout; move it aside or set ALEGO_SRC_DIR"
+fi
+if [ -d "$SRC_DIR/.git" ]; then
+  info "updating existing checkout in $SRC_DIR (local changes there are discarded)"
+  git -C "$SRC_DIR" fetch --depth 1 origin "$REF"
+  git -C "$SRC_DIR" reset --hard FETCH_HEAD --
+else
+  info "cloning $REPO ($REF) into $SRC_DIR"
+  git clone --depth 1 --branch "$REF" "$REPO" "$SRC_DIR"
+fi
+
+info "installing dependencies (pnpm install --frozen-lockfile)"
+pnpm -C "$SRC_DIR" install --frozen-lockfile
+info "building the runtime and Web UI (pnpm run build) — this takes a few minutes"
+pnpm -C "$SRC_DIR" run build
+
+mkdir -p "$BIN_DIR"
+launcher="$BIN_DIR/alego"
+printf '#!/usr/bin/env bash\nexec node "%s/apps/cli/lib/bin.js" "$@"\n' "$SRC_DIR" > "$launcher"
+chmod +x "$launcher"
+
+info "installed $("$launcher" --version 2>/dev/null || echo "launcher") at $launcher"
+case ":$PATH:" in
+  *":$BIN_DIR:"*) ;;
+  *) info "note: $BIN_DIR is not on your PATH; add it, e.g.: export PATH=\"$BIN_DIR:\$PATH\"" ;;
+esac
+info "run: alego web"


### PR DESCRIPTION
Issue: none.

<details>
<summary>Changes and verification</summary>

**`install.sh`** (root): `curl -fsSL https://raw.githubusercontent.com/singula-ai/alego/main/install.sh | bash` verifies `git` and the engines range (`^22.19.0 || >=24`), provides pnpm through `corepack enable` when absent (the `packageManager` pin picks the version), clones `--depth 1` into `ALEGO_SRC_DIR` (default `~/.alego-src` — deliberately not `~/.alego`, which the runtime owns), runs `pnpm install --frozen-lockfile` and the full `pnpm run build`, and writes a two-line `alego` launcher into `ALEGO_BIN_DIR` (default `~/.local/bin`). Re-running updates the checkout and rebuilds; `ALEGO_REPO`/`ALEGO_REF` select fork and branch; no elevation anywhere.

The global command is a written launcher, not a package-manager link: `pnpm link --global` fails with `ERR_PNPM_NO_GLOBAL_BIN_DIR` on machines that never ran `pnpm setup`, and `npm link` installs `apps/cli` in isolation where its `workspace:^` ranges resolve nowhere.

**READMEs** (en + zh, pairing re-recorded): the one-liner joins "Run from source" ahead of the manual steps.

**Agent Note** (bilingual): `2026-08-27-curl-source-install` — decision, rejected alternatives, and constraints.

**Verification**

- End-to-end on a clean prefix: anonymous clone of the public repo, frozen install, full build (200 client artifacts recorded), then `alego --version` → `0.1.2` through the written launcher; the not-on-PATH warning fired for the isolated bin dir. Exit 0.
- `bash -n` clean; doc gates all pass: `verify-agent-note-format`, `verify-translation-pairing` (1007 pairs), `verify-md-wrap`, `verify-md-links`, `verify-doc-budgets`, `verify-public-repository-links`.
- Known check state: four CI jobs remain queued on unavailable larger-runner labels; the doc gates above were run locally since `node 24 / static` cannot run.

</details>
